### PR TITLE
Added page on hardware and improved doc styling

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,16 @@
+dt .sig-param {
+    margin-left: 4em;
+    width: 80%;
+    display: inline-block;
+}
+dt .sig-param .n {
+    font-weight: bold;
+    font-style: normal;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+.py.function, .py.class {
+    border-top: 3px solid #2b2e83;
+    margin-top: 2em;
+    padding-top: 1em;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
     'github_button': 'true',
     'description': 'A library to do deep learning with spiking neural networks.',
 
-    'page_width': '900px',
+    'page_width': '1100px',
     'sidebar_width': '300px'
 }
 
@@ -83,6 +83,8 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+html_css_files = ["custom.css"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),

--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -1,0 +1,75 @@
+.. _page-hardware:
+
+Hardware acceleration
+-------------------
+
+Norse is built on top of `PyTorch <https://pytorch.org>`_ which has excellent support for hardware acceleration. 
+This article will cover how Norse can be accelerated with GPUs through the `CUDA platform <https://en.wikipedia.org/wiki/CUDA>`_.
+
+Since Norse is using PyTorch primitives, it is worth familiarising yourself with the use of GPUs in PyTorch.
+Here is a tutorial describing how to use GPUs with the ``to`` method in PyTorch: 
+https://pytorch.org/tutorials/beginner/nn_tutorial.html#using-your-gpu
+
+Accelerating Norse models with ``.to``
+======================================
+
+To accelerate neuron models in Norse, one simply has to call the ``.to`` method on models and data:
+
+
+.. code:: python
+
+    from norse.torch.module.lif import LIFCell
+    LIFCell(10, 20).to('cuda')
+
+.. code:: python
+
+    import torch
+    torch.randn(100, 20).to('cuda')
+
+Accelerating Norse nested models
+======================================
+
+It might be necessary to sometimes build your own nested `torch.nn` modules. 
+In that case it's recommended to propagate a ``device`` parameter to inner modules, to ensure that data is 
+moved to the GPU as soon as possible.
+
+Here is an example of a nested model that we will move to the GPU
+(taken and simplified from our `MNIST task example <https://github.com/norse/norse/blob/master/norse/task/mnist.py#L60>`_):
+
+.. code:: python
+
+    class LIFConvNet(torch.nn.Module):
+        def __init__(
+            self,
+            input_features,
+            seq_length,
+            model="super",
+            device="cpu"
+        ):
+            super(LIFConvNet, self).__init__()
+            self.constant_current_encoder = ConstantCurrentLIFEncoder(seq_length=seq_length)
+            self.input_features = input_features
+            self.rsnn = ConvNet4(method=model, device=device)
+            self.seq_length = seq_length
+
+        def forward(self, x):
+            batch_size = x.shape[0]
+            x = self.constant_current_encoder(
+                x.view(-1, self.input_features)
+            )
+            x = x.reshape(self.seq_length, batch_size, 1, 28, 28)
+            voltages = self.rsnn(x)
+            m, _ = torch.max(voltages, 0)
+            log_p_y = torch.nn.functional.log_softmax(m, dim=1)
+            return log_p_y
+
+We can now use this model in a ``main`` by initialising it with the correct device:
+
+.. code:: python
+
+    def main(args):
+        device = ...
+        input_features = ...
+        seq_length = ...
+        model = LIFConvNet(input_features, seq_length, device=device).to(device)
+        ...

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -105,6 +105,7 @@ Table of contents
 
    about
    installing
+   hardware
    spiking
    learning
    working
@@ -123,7 +124,6 @@ Table of contents
    :caption: API Docs
    :glob:
    :titlesonly:
-   :numbered:
 
    auto_api/norse.benchmark
    auto_api/norse.module


### PR DESCRIPTION
I was annoyed with some of the documentation styling, so I made distinctions between functions/classes clearer, removed some annoying numbering, and made the page wider.

Also added a page on hardware acceleration as a reply to #98 