### PR TITLE
Feature regularization

### DIFF
--- a/norse/__init__.py
+++ b/norse/__init__.py
@@ -1,7 +1,7 @@
 """Norse is a library for doing deep learning with spiking neural networks.
 """
 
-from . import benchmark, task
+from . import benchmark, dataset, task
 
 from .torch import functional
 from .torch.models import conv
@@ -10,6 +10,7 @@ from .torch.module import lif, lsnn
 __all__ = [
     "task",
     "benchmark",
+    "dataset",
     "functional",
     "conv",
     "lif",

--- a/norse/dataset/__init__.py
+++ b/norse/dataset/__init__.py
@@ -1,0 +1,3 @@
+"""
+Datasets with temporal data, ideal for analysis with spiking neural networks.
+"""

--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -15,6 +15,7 @@ from . import lif_mc
 from . import lif
 from . import lsnn
 from . import logical
+from . import regularization
 from . import stdp_sensor
 from . import superspike
 
@@ -32,6 +33,7 @@ __all__ = [
     lif,
     lsnn,
     logical,
+    regularization,
     stdp_sensor,
     superspike,
 ]

--- a/norse/torch/functional/regularization.py
+++ b/norse/torch/functional/regularization.py
@@ -1,0 +1,62 @@
+"""
+This module contains functional components for regularization operations on
+spiking layers, where it can be desirable to regularize spikes,
+membrane parameters, or other properties over time.
+
+In this functional version, the aim is to collect some state ``s`` for each
+forward step. The collection depends on the output of the layer which, by
+default, simply just counts spikes. It is the job of the user to include the
+regularization in an error term later.
+
+Read more on `Wikipedia <https://en.wikipedia.org/wiki/Regularization_%28mathematics%29>`_.
+"""
+from typing import Any, TypedDict, Callable
+import torch
+
+
+class RegularizationState(TypedDict):
+    """
+    Stateful representation of a single regularisation step.
+    Equivalent to a typed dictionary where any information can be stored in principle.
+    """
+
+
+def spike_accumulator(
+    z: torch.Tensor, s: Any, state: RegularizationState
+) -> RegularizationState:
+    """
+    A spike accumulator that aggregates spikes and stores the total number under `num_spikes`.
+
+    Parameters:
+        z (torch.Tensor): Spikes from some cell
+        s (Any): Cell state
+        state (RegularizationState): The regularization state to be aggregated to
+
+    Returns:
+        A new RegularizationState containing the aggregated data
+    """
+    return RegularizationState(num_spikes=state['num_spikes'] + z.sum())
+
+
+def regularize_step(
+    z: torch.Tensor,
+    s: Any,
+    accumulator: Callable[
+        [torch.Tensor, Any, RegularizationState], RegularizationState
+    ] = spike_accumulator,
+    state=RegularizationState(num_spikes=0),
+):
+    """
+    Takes one step for a regularizer that aggregates some information (based on the
+    spike_accumulator function), which is pushed forward and returned for future
+    inclusion in an error term.
+
+    Parameters:
+        z (torch.Tensor): Spikes from a cell
+        s (Any): Neuron state
+        state (RegularizationState): The regularization state to be aggregated to
+
+    Return:
+        A tuple of (spikes, state, RegularizationState)
+    """
+    return z, s, accumulator(z, s, state)

--- a/norse/torch/functional/test_regularization.py
+++ b/norse/torch/functional/test_regularization.py
@@ -1,16 +1,27 @@
-import torch 
+import torch
 
 from . import lif
 from . import regularization
 
-def regularisation_default_test():
+
+def regularisation_spikes_test():
     x = torch.ones(5, 10)
     s = lif.LIFState(torch.ones(10), torch.ones(10), torch.ones(10))
     z, s = lif.lif_feed_forward_step(x, s)
-    zr, sr, rs = regularization.regularize_step(z, s)
+    zr, rs = regularization.regularize_step(z, s)
     assert torch.all(torch.eq(z, zr))
-    assert torch.all(torch.eq(s.v, sr.v))
-    assert rs['num_spikes'] == 0
+    assert rs == 0
     z, s = lif.lif_feed_forward_step(x, s)
-    zr, sr, rs = regularization.regularize_step(z, s)
-    assert rs['num_spikes'] == 50
+    zr, rs = regularization.regularize_step(z, s)
+    assert rs == 50
+
+
+def regularisation_voltage_test():
+    x = torch.ones(5, 10)
+    s = lif.LIFState(torch.ones(10), torch.ones(10), torch.ones(10))
+    z, s = lif.lif_feed_forward_step(x, s)
+    zr, rs = regularization.regularize_step(
+        z, s, accumulator=regularization.voltage_accumulator
+    )
+    assert torch.all(torch.eq(z, zr))
+    assert torch.all(torch.eq(s.v, rs))

--- a/norse/torch/functional/test_regularization.py
+++ b/norse/torch/functional/test_regularization.py
@@ -1,0 +1,16 @@
+import torch 
+
+from . import lif
+from . import regularization
+
+def regularisation_default_test():
+    x = torch.ones(5, 10)
+    s = lif.LIFState(torch.ones(10), torch.ones(10), torch.ones(10))
+    z, s = lif.lif_feed_forward_step(x, s)
+    zr, sr, rs = regularization.regularize_step(z, s)
+    assert torch.all(torch.eq(z, zr))
+    assert torch.all(torch.eq(s.v, sr.v))
+    assert rs['num_spikes'] == 0
+    z, s = lif.lif_feed_forward_step(x, s)
+    zr, sr, rs = regularization.regularize_step(z, s)
+    assert rs['num_spikes'] == 50

--- a/norse/torch/module/regularization.py
+++ b/norse/torch/module/regularization.py
@@ -1,0 +1,48 @@
+"""
+This module contains ``torch.nn.Module``s for regularisation operations on
+spiking layers, where it can be desirable to regularise spikes,
+membrane parameters, or other properties over time.
+"""
+import torch
+
+from norse.torch.functional.regularization import (
+    regularize_step,
+    spike_accumulator,
+    T,
+    Accumulator,
+)
+
+
+class RegularizationCell(torch.nn.Module):
+    """
+    A regularisation cell that accumulates some state (for instance number of spikes)
+    for each forward step, which can later be applied to a loss term.
+
+    Example:
+        >>> import torch
+        >>> from norse.torch.module import lif, regularization
+        >>> cell = lif.LIFCell(2, 4) # 2 -> 4
+        >>> r = regularization.RegularizationCell() # Defaults to spike counting
+        >>> data = torch.ones(5, 2)  # Batch size of 5
+        >>> s = cell.initial_state(5, device='cpu')
+        >>> z, s = cell(data, s)
+        >>> z, regularization_term = r(z, s)
+        >>> ...
+        >>> loss = ... + 1e-3 * regularization_term
+
+    Parameters:
+        accumulator (Accumulator):
+            The accumulator that aggregates some data (such as spikes) that can later
+            be included in an error term.
+        state (Optional[T]): The regularization state to be aggregated to of any type T. Defaults to None.
+    """
+
+    def __init__(self, accumulator: Accumulator = spike_accumulator, state: T = None):
+        super(RegularizationCell, self).__init__()
+        self.accumulator = accumulator
+        self.state = state
+
+    def forward(self, z, s):
+        _, state = regularize_step(z, s, self.accumulator, self.state)
+        self.state = state
+        return z, self.state

--- a/norse/torch/module/test/test_regularization.py
+++ b/norse/torch/module/test/test_regularization.py
@@ -1,0 +1,17 @@
+import torch
+from .. import lif
+from ..regularization import RegularizationCell
+
+
+def regularization_module_test():
+    cell = lif.LIFFeedForwardCell((2,))  # 2 -> 4
+    r = RegularizationCell()  # Defaults to spike counting
+    data = torch.ones(5, 2) + 10  # Batch size of 5
+    s = cell.initial_state(5, device="cpu")
+    z, s = cell(data, s)
+    z, rs = r(z, s)
+    assert rs == 0
+    z, s = cell(data, s)
+    z, rs = r(z, s)
+    assert rs == 10
+    assert r.state == 10


### PR DESCRIPTION
Implemented regularization by adding stateless functional accumulators as well as a stateful `RegularizationCell` module.
I chose not to implement a full `RegularizationState` NamedTuple just to avoid having to wrap the code in more types. Currently it should be straight-forward to both use and extend:

        >>> import torch
        >>> from norse.torch.module import lif, regularization
        >>> cell = lif.LIFCell(2, 4) # 2 -> 4
        >>> r = regularization.RegularizationCell() # Defaults to spike counting
        >>> data = torch.ones(5, 2)  # Batch size of 5
        >>> s = cell.initial_state(5, device='cpu')
        >>> z, s = cell(data, s)
        >>> z, rs = r(z, s)
        >>> print(rs) # 0 spikes yet
