### PR TITLE
Remove redundant initial_state by inferring device and dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,11 @@ More information and tasks are available [in our documentation](https://norse.gi
 The long short-term spiking neural networks from the paper by [G. Bellec, D. Salaj, A. Subramoney, R. Legenstein, and W. Maass (2018)](https://arxiv.org/abs/1803.09574) is one interesting way to apply norse: 
 ```python
 from norse.torch.module import LSNNLayer, LSNNCell
-# LSNNCell with 2 inputs and 10 outputs
+# LSNNCell with 2 input neurons and 10 output neurons
 layer = LSNNLayer(LSNNCell, 2, 10)
-# 5 batch size running on CPU
-state = layer.initial_state(5, "cpu")
-# Generate data (20 timesteps with 8 sequences simultaneously)
+# Generate data: 20 timesteps with 8 datapoints per batch for 2 neurons
 data  = torch.zeros(20, 8, 2)
-# Tuple of output data of shape (8, 2) and layer state
+# Tuple of (output data of shape (8, 2), layer state)
 output, new_state = layer.forward(data, state)
 ```
 

--- a/docs/source/working.rst
+++ b/docs/source/working.rst
@@ -46,19 +46,24 @@ Every time you call a neuron, the state will be returned along with the output (
 Typically as the second parameter.
 The reason for this is that you can then re-use the state in the next time step, to capture the neuron parameters.
 
-The initial value of such a state is found by invoking the ``initial_state`` of the cell/layer, like so:
+The initial value of such a state defaults to meaningful values for each neuron models, but can be
+also be manually configured if needed:
 
 .. code:: python
 
     import torch
     from norse.torch.module.lif import LIFCell
-    data = torch.ones(2)
+    data = torch.ones(8, 2)  # 8 batches, 2 inputs
     cell = LIFCell(2, 4)     # Shape 2 -> 4
-    state = cell.initial_state(8, "cpu")
+    z, s = cell(data)        # Invoke with default state
 
-This informs the cell that there are 8 entries in the batches and that the data will be evaluated on the CPU.
+    state = cell.initial_state(8)
+    z, s = cell(data, state) # Invoke with custom state
 
-Here is an example on how to evaluate a sequence of inputs modified from the `LIFLayer <https://github.com/norse/norse/blob/master/norse/torch/module/lif.py#L106>`_.
+This informs the cell that there are 8 entries in a batch, each providing input to 2 neurons.
+
+Here is an example on how to evaluate a sequence of inputs modified from the
+`LIFLayer <https://github.com/norse/norse/blob/master/norse/torch/module/lif.py#L106>`_.
 
 
 .. code:: python
@@ -68,7 +73,6 @@ Here is an example on how to evaluate a sequence of inputs modified from the `LI
     inputs = torch.ones(100, 8, 2) # Shape (timesteps, batch, input)
     
     cell = LIFCell(2, 4)           # Shape (input, output)
-    state = cell.initial_state(8, "cpu")
     outputs = []
         for i in range(len(inputs)):
             out, state = self.cell(inputs[i], state)

--- a/norse/benchmark/main.py
+++ b/norse/benchmark/main.py
@@ -58,7 +58,9 @@ def benchmark(
                 logging.error(message)
 
             data = BenchmarkData(
-                config=config, durations=np.array(durations), parameters=parameters,
+                config=config,
+                durations=np.array(durations),
+                parameters=parameters,
             )
             result = collector(data)
 

--- a/norse/benchmark/norse_lif.py
+++ b/norse/benchmark/norse_lif.py
@@ -16,11 +16,13 @@ def lif_feed_forward_benchmark(parameters: BenchmarkParameters):
         parameters.device
     )
     T = parameters.sequence_length
-    s = LIFFeedForwardState(
-        v=torch.zeros(parameters.batch_size, parameters.features).to(parameters.device),
-        i=torch.zeros(parameters.batch_size, parameters.features).to(parameters.device),
-    )
     p = LIFParameters(alpha=100.0, method="heaviside")
+    s = LIFFeedForwardState(
+        v=p.v_leak,
+        i=torch.zeros(
+            parameters.batch_size, parameters.features, device=parameters.device
+        ),
+    )
     input_spikes = PoissonEncoder(T, dt=parameters.dt)(
         0.3
         * torch.ones(

--- a/norse/examples/plot_mnist.py
+++ b/norse/examples/plot_mnist.py
@@ -25,7 +25,6 @@ from norse.torch.module.lif import LIFFeedForwardCell
 class Net(torch.nn.Module):
     def __init__(
         self,
-        device="cpu",
         num_channels=1,
         feature_size=32,
         model="super",
@@ -49,30 +48,24 @@ class Net(torch.nn.Module):
             (1024,), p=LIFParameters(method=model, alpha=100.0)
         )
         self.out = LICell(1024, 10)
-        self.device = device
         self.dtype = dtype
+        # One would normally also define the device here
+        # However, Norse has been built to infer the device type from the input data
+        # It is still possible to enforce the device type on initialisation
+        # More details are available in our documentation:
+        #   https://norse.github.io/norse/hardware.html
 
     def forward(self, x):
         seq_length = x.shape[0]
         seq_batch_size = x.shape[1]
 
         # specify the initial states
-        s0 = self.lif0.initial_state(
-            seq_batch_size, device=self.device, dtype=self.dtype
-        )
-        s1 = self.lif1.initial_state(
-            seq_batch_size, device=self.device, dtype=self.dtype
-        )
-        s2 = self.lif2.initial_state(
-            seq_batch_size, device=self.device, dtype=self.dtype
-        )
-        so = self.out.initial_state(
-            seq_batch_size, device=self.device, dtype=self.dtype
-        )
+        s0 = None
+        s1 = None
+        s2 = None
+        so = None
 
-        voltages = torch.zeros(
-            seq_length, seq_batch_size, 10, device=self.device, dtype=self.dtype
-        )
+        voltages = torch.zeros(seq_length, seq_batch_size, 10, dtype=self.dtype)
 
         for ts in range(seq_length):
             z = self.conv1(x[ts, :])

--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -114,22 +114,17 @@ def signed_poisson_train(images, seq_length, rel_fmax=0.2):
 
 
 class LIFConvNet(torch.nn.Module):
-    def __init__(self, num_channels, device="cpu"):
+    def __init__(self, num_channels):
         super(LIFConvNet, self).__init__()
 
         if FLAGS.net == "convnet":
             dtype = torch.float
-            self.rsnn = ConvNet(
-                device=device, num_channels=num_channels, feature_size=32, dtype=dtype
-            )
+            self.rsnn = ConvNet(num_channels=num_channels, feature_size=32, dtype=dtype)
         elif FLAGS.net == "convnet4":
-            self.rsnn = ConvNet4(
-                device=device, num_channels=num_channels, feature_size=32
-            )
-        self.device = device
+            self.rsnn = ConvNet4(num_channels=num_channels, feature_size=32)
 
     def forward(self, x):
-        voltages = self.rsnn(x.to(self.device).permute(1, 0, 2, 3, 4))
+        voltages = self.rsnn(x).permute(1, 0, 2)
         m, _ = torch.max(voltages, 0)
         log_p_y = torch.nn.functional.log_softmax(m, dim=1)
         return log_p_y
@@ -351,7 +346,7 @@ def main(args):
     os.chdir(rundir)
     FLAGS.append_flags_into_file("flags.txt")
 
-    model = LIFConvNet(num_channels=num_channels, device=device,).to(device)
+    model = LIFConvNet(num_channels=num_channels).to(device)
 
     print(model)
 

--- a/norse/task/correlation_experiment.py
+++ b/norse/task/correlation_experiment.py
@@ -75,8 +75,8 @@ def main():
     num_episodes = 100
 
     for e in range(num_episodes):
-        s1 = lif_correlation.initial_state(batch_size, device=device)
-        so = out.initial_state(batch_size, device=device)
+        s1 = None
+        so = None
 
         voltages = torch.zeros(seq_length, batch_size, output_features, device=device)
         hidden_voltages = torch.zeros(
@@ -91,9 +91,9 @@ def main():
         for ts in range(seq_length):
             z1, s1 = lif_correlation(
                 x[ts, :, :],
-                s1,
                 input_weights=input_weights,
                 recurrent_weights=recurrent_weights,
+                state=s1,
             )
 
             input_weights = correlation_based_update(

--- a/norse/task/memory.py
+++ b/norse/task/memory.py
@@ -25,7 +25,10 @@ flags.DEFINE_enum(
     "Model to use for training.",
 )
 flags.DEFINE_enum(
-    "neuron_model", "lsnn", ["lsnn", "lif"], "Neuron model to use in network.",
+    "neuron_model",
+    "lsnn",
+    ["lsnn", "lif"],
+    "Neuron model to use in network.",
 )
 flags.DEFINE_enum(
     "optimizer", "adam", ["adam", "sgd"], "Optimizer to use for training."
@@ -56,7 +59,9 @@ flags.DEFINE_integer(
     "seq_steps", 24, "Number of steps in each experiment (should be at least 8)."
 )
 flags.DEFINE_integer(
-    "seq_repetitions", 24, "Number of times a sequence is repeated.",
+    "seq_repetitions",
+    24,
+    "Number of times a sequence is repeated.",
 )
 flags.DEFINE_float("weight_decay", 1e-5, "Weight decay (L2 regularisation penalty).")
 
@@ -88,8 +93,8 @@ class MemoryNet(torch.nn.Module):
     def forward(self, x):
         batch_size = x.shape[0]
 
-        sl = self.layer.initial_state(batch_size, x.device, x.dtype)
-        sr = self.readout.initial_state(batch_size, x.device, x.dtype)
+        sl = None
+        sr = None
         seq_spikes = []
         step_spikes = []
         seq_readouts = []
@@ -254,7 +259,13 @@ def _plot_run(
 
 
 def train(
-    model, data_loader, optimizer, epoch, total_epochs, log_interval=1e10, writer=None,
+    model,
+    data_loader,
+    optimizer,
+    epoch,
+    total_epochs,
+    log_interval=1e10,
+    writer=None,
 ):
     model.train()
     losses = []

--- a/norse/task/mnist.py
+++ b/norse/task/mnist.py
@@ -63,15 +63,13 @@ class LIFConvNet(torch.nn.Module):
         input_features,
         seq_length,
         model="super",
-        device="cpu",
         only_first_spike=False,
     ):
         super(LIFConvNet, self).__init__()
         self.constant_current_encoder = ConstantCurrentLIFEncoder(seq_length=seq_length)
         self.only_first_spike = only_first_spike
         self.input_features = input_features
-        self.rsnn = ConvNet4(device=device, method=model)
-        self.device = device
+        self.rsnn = ConvNet4(method=model)
         self.seq_length = seq_length
 
     def forward(self, x):
@@ -88,7 +86,7 @@ class LIFConvNet(torch.nn.Module):
                 if spike_counter[batch, nrn] == 0:
                     zeros[t, batch, nrn] = 1
                     spike_counter[batch, nrn] += 1
-            x = torch.from_numpy(zeros).to(self.device)
+            x = torch.from_numpy(zeros).to(x.device)
 
         x = x.reshape(self.seq_length, batch_size, 1, 28, 28)
         voltages = self.rsnn(x)
@@ -279,7 +277,6 @@ def main(argv):
         input_features,
         FLAGS.seq_length,
         model=FLAGS.model,
-        device=device,
         only_first_spike=FLAGS.only_first_spike,
     ).to(device)
 

--- a/norse/task/speech_commands/model.py
+++ b/norse/task/speech_commands/model.py
@@ -17,8 +17,8 @@ class SNNModel(torch.nn.Module):
         seq_length = x.shape[0]
         batch_size = x.shape[1]
 
-        s = self.cell.initial_state(batch_size, x.device, x.dtype)
-        so = self.readout.initial_state(batch_size, x.device, x.dtype)
+        s = None
+        so = None
 
         for ts in range(seq_length):
             z, s = self.cell(x[ts, :], s)

--- a/norse/torch/functional/correlation_sensor.py
+++ b/norse/torch/functional/correlation_sensor.py
@@ -23,8 +23,7 @@ def post_mask(weights, z):
 
 @torch.jit.script
 def post_pre_update(post_pre, post_spike_mask, pre_spike_mask):
-    """Computes which synapses in the synapse array should be updated.
-    """
+    """Computes which synapses in the synapse array should be updated."""
     return heaviside(post_pre + post_spike_mask - pre_spike_mask)
 
 

--- a/norse/torch/functional/encode.py
+++ b/norse/torch/functional/encode.py
@@ -18,7 +18,7 @@ def constant_current_lif_encode(
     dt: float = 0.001,
 ) -> torch.Tensor:
     """
-    Encodes input currents as fixed (constant) voltage currents, and simulates the spikes that 
+    Encodes input currents as fixed (constant) voltage currents, and simulates the spikes that
     occur during a number of timesteps/iterations (seq_length).
 
     Example:
@@ -26,10 +26,10 @@ def constant_current_lif_encode(
         >>> seq_length = 2 # Simulate two iterations
         >>> constant_current_lif_encode(data, seq_length)
          # State in terms of membrane voltage
-        (tensor([[0.2000, 0.4000, 0.8000, 0.0000],   
-                 [0.3800, 0.7600, 0.0000, 0.0000]]), 
+        (tensor([[0.2000, 0.4000, 0.8000, 0.0000],
+                 [0.3800, 0.7600, 0.0000, 0.0000]]),
          # Spikes for each iteration
-         tensor([[0., 0., 0., 1.],                   
+         tensor([[0., 0., 0., 1.],
                  [0., 0., 1., 1.]]))
 
     Parameters:
@@ -54,7 +54,7 @@ def constant_current_lif_encode(
 def gaussian_rbf(tensor: torch.Tensor, sigma: float = 1):
     """
     A `gaussian radial basis kernel <https://en.wikipedia.org/wiki/Radial_basis_function_kernel>`_
-    that calculates the radial basis given a distance value (distance between :math:`x` and a data 
+    that calculates the radial basis given a distance value (distance between :math:`x` and a data
     value :math:`x'`, or :math:`\|\mathbf{x} - \mathbf{x'}\|^2` below).
 
     .. math::
@@ -126,7 +126,10 @@ def population_encode(
 
 
 def poisson_encode(
-    input_values: torch.Tensor, seq_length: int, f_max: float = 100, dt: float = 0.001,
+    input_values: torch.Tensor,
+    seq_length: int,
+    f_max: float = 100,
+    dt: float = 0.001,
 ) -> torch.Tensor:
     """
     Encodes a tensor of input values, which are assumed to be in the
@@ -209,13 +212,13 @@ def spike_latency_lif_encode(
 
 def spike_latency_encode(input_spikes: torch.Tensor) -> torch.Tensor:
     """
-    For all neurons, remove all but the first spike. This encoding basically measures the time it takes for a 
+    For all neurons, remove all but the first spike. This encoding basically measures the time it takes for a
     neuron to spike *first*. Assuming that the inputs are constant, this makes sense in that strong inputs spikes
     fast.
 
     See `R. Van Rullen & S. J. Thorpe (2001): Rate Coding Versus Temporal Order Coding: What the Retinal Ganglion Cells Tell the Visual Cortex <https://doi.org/10.1162/08997660152002852>`_.
 
-    Spikes are identified by their unique position within each sequence. 
+    Spikes are identified by their unique position within each sequence.
 
     Example:
         >>> data = torch.tensor([[0, 1, 1], [1, 1, 1]])

--- a/norse/torch/functional/heaviside.py
+++ b/norse/torch/functional/heaviside.py
@@ -10,5 +10,7 @@ def heaviside(data):
         H[n]=\\begin{cases} 0, & n <= 0, \\ 1, & n \g 0, \end{cases}
     """
     return torch.where(
-        data <= torch.zeros_like(data), torch.zeros_like(data), torch.ones_like(data),
+        data <= torch.zeros_like(data),
+        torch.zeros_like(data),
+        torch.ones_like(data),
     )

--- a/norse/torch/functional/lif.py
+++ b/norse/torch/functional/lif.py
@@ -32,7 +32,11 @@ class LIFParameters(NamedTuple):
 
 
 default_bio_parameters = LIFParameters(
-    tau_syn_inv=1 / 0.5, tau_mem_inv=1 / 20.0, v_leak=-65.0, v_th=-50.0, v_reset=-65.0,
+    tau_syn_inv=1 / 0.5,
+    tau_mem_inv=1 / 20.0,
+    v_leak=-65.0,
+    v_th=-50.0,
+    v_reset=-65.0,
 )
 
 

--- a/norse/torch/functional/lif_correlation.py
+++ b/norse/torch/functional/lif_correlation.py
@@ -20,8 +20,12 @@ class LIFCorrelationState(NamedTuple):
 
 class LIFCorrelationParameters(NamedTuple):
     lif_parameters: LIFParameters = LIFParameters()
-    input_correlation_parameters: CorrelationSensorParameters = CorrelationSensorParameters()
-    recurrent_correlation_parameters: CorrelationSensorParameters = CorrelationSensorParameters()
+    input_correlation_parameters: CorrelationSensorParameters = (
+        CorrelationSensorParameters()
+    )
+    recurrent_correlation_parameters: CorrelationSensorParameters = (
+        CorrelationSensorParameters()
+    )
 
 
 def lif_correlation_step(

--- a/norse/torch/functional/stdp.py
+++ b/norse/torch/functional/stdp.py
@@ -1,4 +1,8 @@
-from typing import Callable, NamedTuple
+import torch
+from typing import NamedTuple
+from norse.torch.functional.heaviside import heaviside
+
+from norse.torch.functional.stdp_sensor import STDPSensorState
 
 
 class STDPState(NamedTuple):

--- a/norse/torch/functional/superspike.py
+++ b/norse/torch/functional/superspike.py
@@ -5,10 +5,10 @@ from .heaviside import heaviside
 class SuperSpike(torch.autograd.Function):
     """SuperSpike surrogate gradient as described in Section 3.3.2 of
 
-        F. Zenke, S. Ganguli, "SuperSpike: Supervised Learning in
-                               Multilayer Spiking Neural Networks",
-        Neural Computation 30, 1514–1541 (2018),
-        doi:10.1162/neco_a_01086
+    F. Zenke, S. Ganguli, "SuperSpike: Supervised Learning in
+                           Multilayer Spiking Neural Networks",
+    Neural Computation 30, 1514–1541 (2018),
+    doi:10.1162/neco_a_01086
     """
 
     @staticmethod

--- a/norse/torch/functional/threshold.py
+++ b/norse/torch/functional/threshold.py
@@ -22,7 +22,10 @@ class HeaviErfc(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, k, = ctx.saved_tensors
+        (
+            x,
+            k,
+        ) = ctx.saved_tensors
         derfc = (2 * torch.exp(-k.pow(2) * x.pow(2))) / (torch.as_tensor(np.pi).sqrt())
         return derfc * dy, None
 
@@ -44,7 +47,10 @@ class HeaviTanh(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, k, = ctx.saved_tensors
+        (
+            x,
+            k,
+        ) = ctx.saved_tensors
         dtanh = 1 - (x * k).tanh().pow(2)
         return dy * dtanh, None
 
@@ -67,7 +73,10 @@ class Logistic(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, k, = ctx.saved_tensors
+        (
+            x,
+            k,
+        ) = ctx.saved_tensors
         dtanh = 1 - (x * k).tanh().pow(2)
         return dy * dtanh, None
 
@@ -90,7 +99,7 @@ class HeaviCirc(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, alpha, = ctx.saved_tensors
+        (x, alpha) = ctx.saved_tensors
 
         return (
             dy
@@ -117,7 +126,10 @@ class CircDist(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, alpha, = ctx.saved_tensors
+        (
+            x,
+            alpha,
+        ) = ctx.saved_tensors
         return (
             dy
             * (
@@ -141,7 +153,10 @@ class HeaviTent(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dy):
-        x, alpha, = ctx.saved_tensors
+        (
+            x,
+            alpha,
+        ) = ctx.saved_tensors
         return torch.relu(1 - torch.abs(x)) * alpha * dy, None
 
 

--- a/norse/torch/models/conv.py
+++ b/norse/torch/models/conv.py
@@ -7,7 +7,7 @@ from norse.torch.module.lif import LIFFeedForwardCell
 
 class ConvNet(torch.nn.Module):
     def __init__(
-        self, device, num_channels=1, feature_size=28, method="super", dtype=torch.float
+        self, num_channels=1, feature_size=28, method="super", dtype=torch.float
     ):
         super(ConvNet, self).__init__()
         self.features = int(((feature_size - 4) / 2 - 4) / 2)
@@ -15,7 +15,6 @@ class ConvNet(torch.nn.Module):
         self.conv2 = torch.nn.Conv2d(20, 50, 5, 1)
         self.fc1 = torch.nn.Linear(self.features * self.features * 50, 500)
         self.out = LICell(500, 10)
-        self.device = device
         self.lif0 = LIFFeedForwardCell(
             (20, feature_size - 4, feature_size - 4),
             p=LIFParameters(method=method, alpha=100.0),
@@ -34,13 +33,13 @@ class ConvNet(torch.nn.Module):
         batch_size = x.shape[1]
 
         # specify the initial states
-        s0 = self.lif0.initial_state(batch_size, self.device, self.dtype)
-        s1 = self.lif1.initial_state(batch_size, self.device, self.dtype)
-        s2 = self.lif2.initial_state(batch_size, self.device, self.dtype)
-        so = self.out.initial_state(batch_size, device=self.device, dtype=self.dtype)
+        s0 = None
+        s1 = None
+        s2 = None
+        so = None
 
         voltages = torch.zeros(
-            seq_length, batch_size, 10, device=self.device, dtype=self.dtype
+            seq_length, batch_size, 10, device=x.device, dtype=self.dtype
         )
 
         for ts in range(seq_length):
@@ -60,7 +59,7 @@ class ConvNet(torch.nn.Module):
 
 class ConvNet4(torch.nn.Module):
     def __init__(
-        self, device, num_channels=1, feature_size=28, method="super", dtype=torch.float
+        self, num_channels=1, feature_size=28, method="super", dtype=torch.float
     ):
         super(ConvNet4, self).__init__()
         self.features = int(((feature_size - 4) / 2 - 4) / 2)
@@ -80,7 +79,6 @@ class ConvNet4(torch.nn.Module):
             (1024,), p=LIFParameters(method=method, alpha=100.0)
         )
         self.out = LICell(1024, 10)
-        self.device = device
         self.dtype = dtype
 
     def forward(self, x):
@@ -88,13 +86,13 @@ class ConvNet4(torch.nn.Module):
         batch_size = x.shape[1]
 
         # specify the initial states
-        s0 = self.lif0.initial_state(batch_size, device=self.device, dtype=self.dtype)
-        s1 = self.lif1.initial_state(batch_size, device=self.device, dtype=self.dtype)
-        s2 = self.lif2.initial_state(batch_size, device=self.device, dtype=self.dtype)
-        so = self.out.initial_state(batch_size, device=self.device, dtype=self.dtype)
+        s0 = None
+        s1 = None
+        s2 = None
+        so = None
 
         voltages = torch.zeros(
-            seq_length, batch_size, 10, device=self.device, dtype=self.dtype
+            seq_length, batch_size, 10, device=x.device, dtype=self.dtype
         )
 
         for ts in range(seq_length):

--- a/norse/torch/module/coba_lif.py
+++ b/norse/torch/module/coba_lif.py
@@ -1,10 +1,10 @@
 import torch
 
+from typing import Optional, Tuple
+import numpy as np
+
 from ..functional.coba_lif import CobaLIFParameters, CobaLIFState
 from ..functional.coba_lif import coba_lif_step
-
-from typing import Tuple
-import numpy as np
 
 
 class CobaLIFCell(torch.nn.Module):
@@ -50,8 +50,7 @@ class CobaLIFCell(torch.nn.Module):
         >>> batch_size = 16
         >>> lif = CobaLIFCell(10, 20)
         >>> input = torch.randn(batch_size, 10)
-        >>> s0 = lif.initial_state(batch_size)
-        >>> output, s0 = lif(input, s0)
+        >>> output, s0 = lif(input)
     """
 
     def __init__(
@@ -71,19 +70,36 @@ class CobaLIFCell(torch.nn.Module):
         self.p = p
         self.dt = dt
 
-    def initial_state(
-        self, batch_size: int, device: torch.device, dtype=torch.float
-    ) -> CobaLIFState:
-        return CobaLIFState(
-            z=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            v=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            g_e=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            g_i=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-        )
-
     def forward(
-        self, input_tensor: torch.Tensor, state: CobaLIFState
+        self, input_tensor: torch.Tensor, state: Optional[CobaLIFState]
     ) -> Tuple[torch.Tensor, CobaLIFState]:
+        if state is None:
+            state = CobaLIFState(
+                z=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor.dtype,
+                ),
+                v=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor.dtype,
+                ),
+                g_e=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor.dtype,
+                ),
+                g_i=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor.dtype,
+                ),
+            )
         return coba_lif_step(
             input_tensor,
             state,

--- a/norse/torch/module/encode.py
+++ b/norse/torch/module/encode.py
@@ -17,7 +17,7 @@ class ConstantCurrentLIFEncoder(torch.nn.Module):
         dt: float = 0.001,
     ):
         """
-        Encodes input currents as fixed (constant) voltage currents, and simulates the spikes that 
+        Encodes input currents as fixed (constant) voltage currents, and simulates the spikes that
         occur during a number of timesteps/iterations (seq_length).
 
         Example:
@@ -25,7 +25,7 @@ class ConstantCurrentLIFEncoder(torch.nn.Module):
             >>> seq_length = 2 # Simulate two iterations
             >>> constant_current_lif_encode(data, seq_length)
             (tensor([[0.2000, 0.4000, 0.8000, 0.0000],   # State in terms of membrane voltage
-                    [0.3800, 0.7600, 0.0000, 0.0000]]), 
+                    [0.3800, 0.7600, 0.0000, 0.0000]]),
             tensor([[0., 0., 0., 1.],                   # Spikes for each iteration
                     [0., 0., 1., 1.]]))
 
@@ -41,7 +41,10 @@ class ConstantCurrentLIFEncoder(torch.nn.Module):
 
     def forward(self, input_currents):
         return encode.constant_current_lif_encode(
-            input_currents, seq_length=self.seq_length, p=self.p, dt=self.dt,
+            input_currents,
+            seq_length=self.seq_length,
+            p=self.p,
+            dt=self.dt,
         )
 
 
@@ -49,7 +52,7 @@ class PoissonEncoder(torch.nn.Module):
     def __init__(self, seq_length: int, f_max: float = 100, dt: float = 0.001):
         """
         Encodes a tensor of input values, which are assumed to be in the
-        range [0,1] (if not signed, [-1,1] if signed) 
+        range [0,1] (if not signed, [-1,1] if signed)
         into a tensor of one dimension higher of binary values,
         which represent input spikes.
 
@@ -129,7 +132,7 @@ class SignedPoissonEncoder(torch.nn.Module):
     def __init__(self, seq_length: int, f_max: float = 100, dt: float = 0.001):
         """
         Encodes a tensor of input values, which are assumed to be in the
-        range [-1,1] (if not signed, [-1,1] if signed) 
+        range [-1,1] (if not signed, [-1,1] if signed)
         into a tensor of one dimension higher of binary values,
         which represent input spikes.
 
@@ -174,13 +177,13 @@ class SpikeLatencyLIFEncoder(torch.nn.Module):
 
 class SpikeLatencyEncoder(torch.nn.Module):
     """
-    For all neurons, remove all but the first spike. This encoding basically measures the time it takes for a 
+    For all neurons, remove all but the first spike. This encoding basically measures the time it takes for a
     neuron to spike *first*. Assuming that the inputs are constant, this makes sense in that strong inputs spikes
     fast.
 
     See `R. Van Rullen & S. J. Thorpe (2001): Rate Coding Versus Temporal Order Coding: What the Retinal Ganglion Cells Tell the Visual Cortex <https://doi.org/10.1162/08997660152002852>`_.
 
-    Spikes are identified by their unique position in the input array. 
+    Spikes are identified by their unique position in the input array.
 
     Example:
         >>> data = torch.tensor([[0, 1, 1], [1, 1, 1]])

--- a/norse/torch/module/if_current_encoder.py
+++ b/norse/torch/module/if_current_encoder.py
@@ -12,14 +12,12 @@ class IFConstantCurrentEncoder(torch.nn.Module):
         v_th=1.0,
         v_reset=0.0,
         dt: float = 0.001,
-        device="cpu",
     ):
         super(IFConstantCurrentEncoder, self).__init__()
         self.seq_length = seq_length
         self.tau_mem_inv = tau_mem_inv
         self.v_th = v_th
         self.v_reset = v_reset
-        self.device = device
         self.dt = dt
 
     def forward(self, x):

--- a/norse/torch/module/lif_mc.py
+++ b/norse/torch/module/lif_mc.py
@@ -1,10 +1,10 @@
 import torch
 
+import numpy as np
+from typing import Optional, Tuple
+
 from ..functional.lif import LIFState, LIFParameters
 from ..functional.lif_mc import lif_mc_step
-
-import numpy as np
-from typing import Tuple
 
 
 class LIFMCCell(torch.nn.Module):
@@ -65,18 +65,25 @@ class LIFMCCell(torch.nn.Module):
         self.p = p
         self.dt = dt
 
-    def initial_state(
-        self, batch_size: int, device: torch.device, dtype=torch.float
-    ) -> LIFState:
-        return LIFState(
-            z=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            v=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            i=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-        )
-
     def forward(
-        self, input_tensor: torch.Tensor, state: LIFState
+        self, input_tensor: torch.Tensor, state: Optional[LIFState] = None
     ) -> Tuple[torch.Tensor, LIFState]:
+        if state is None:
+            state = LIFState(
+                z=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor,
+                ),
+                v=self.p.v_leak,
+                i=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor,
+                ),
+            )
         return lif_mc_step(
             input_tensor,
             state,

--- a/norse/torch/module/lif_mc_refrac.py
+++ b/norse/torch/module/lif_mc_refrac.py
@@ -5,7 +5,7 @@ from ..functional.lif import LIFState
 from ..functional.lif_mc_refrac import lif_mc_refrac_step
 
 import numpy as np
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 class LIFMCRefracCell(torch.nn.Module):
@@ -28,21 +28,33 @@ class LIFMCRefracCell(torch.nn.Module):
         self.p = p
         self.dt = dt
 
-    def initial_state(
-        self, batch_size: int, device: torch.device, dtype: torch.float = torch.float
-    ) -> LIFRefracState:
-        return LIFRefracState(
-            lif=LIFState(
-                z=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-                v=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-                i=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-            ),
-            rho=torch.zeros(batch_size, self.hidden_size, device=device, dtype=dtype),
-        )
-
     def forward(
-        self, input_tensor: torch.Tensor, state: LIFRefracState
+        self, input_tensor: torch.Tensor, state: Optional[LIFRefracState] = None
     ) -> Tuple[torch.Tensor, LIFRefracState]:
+        if state is None:
+            state = LIFRefracState(
+                lif=LIFState(
+                    z=torch.zeros(
+                        input_tensor.shape[0],
+                        self.hidden_size,
+                        device=input_tensor.device,
+                        dtype=input_tensor.dtype,
+                    ),
+                    v=self.p.lif.v_leak,
+                    i=torch.zeros(
+                        input_tensor.shape[0],
+                        self.hidden_size,
+                        device=input_tensor.device,
+                        dtype=input_tensor.dtype,
+                    ),
+                ),
+                rho=torch.zeros(
+                    input_tensor.shape[0],
+                    self.hidden_size,
+                    device=input_tensor.device,
+                    dtype=input_tensor.dtype,
+                ),
+            )
         return lif_mc_refrac_step(
             input_tensor,
             state,

--- a/norse/torch/module/regularization.py
+++ b/norse/torch/module/regularization.py
@@ -24,8 +24,7 @@ class RegularizationCell(torch.nn.Module):
         >>> cell = lif.LIFCell(2, 4) # 2 -> 4
         >>> r = regularization.RegularizationCell() # Defaults to spike counting
         >>> data = torch.ones(5, 2)  # Batch size of 5
-        >>> s = cell.initial_state(5, device='cpu')
-        >>> z, s = cell(data, s)
+        >>> z, s = cell(data)
         >>> z, regularization_term = r(z, s)
         >>> ...
         >>> loss = ... + 1e-3 * regularization_term

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -5,9 +5,8 @@ import numpy as np
 
 def test_lif_cell():
     cell = lif.LIFCell(2, 4)
-    data = torch.randn(10, 5, 2)
-    state = cell.initial_state(5, "cpu")
-    out, _ = cell(data, state)
+    data = torch.randn(5, 2)
+    out, _ = cell(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 4]))
 
@@ -15,8 +14,7 @@ def test_lif_cell():
 def test_lif_layer():
     layer = lif.LIFLayer(2, 4)
     data = torch.randn(10, 5, 2)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([10, 5, 4]))
 
@@ -24,7 +22,6 @@ def test_lif_layer():
 def test_lif_feedforward_cell():
     layer = lif.LIFFeedForwardCell((2, 4))
     data = torch.randn(5, 2, 4)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 2, 4]))

--- a/norse/torch/module/test/test_lif_adex.py
+++ b/norse/torch/module/test/test_lif_adex.py
@@ -5,9 +5,8 @@ import numpy as np
 
 def test_lif_adex_cell():
     cell = lif_adex.LIFAdExCell(2, 4)
-    data = torch.randn(10, 5, 2)
-    state = cell.initial_state(5, "cpu")
-    out, _ = cell(data, state)
+    data = torch.randn(5, 2)
+    out, _ = cell(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 4]))
 
@@ -15,8 +14,7 @@ def test_lif_adex_cell():
 def test_lif_adex_layer():
     layer = lif_adex.LIFAdExLayer(2, 4)
     data = torch.randn(10, 5, 2)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([10, 5, 4]))
 
@@ -24,7 +22,6 @@ def test_lif_adex_layer():
 def test_lif_adex_feedforward_cell():
     layer = lif_adex.LIFAdExFeedForwardCell((2, 4))
     data = torch.randn(5, 2, 4)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 2, 4]))

--- a/norse/torch/module/test/test_lif_ex.py
+++ b/norse/torch/module/test/test_lif_ex.py
@@ -5,9 +5,8 @@ import numpy as np
 
 def test_lif_ex_cell():
     cell = lif_ex.LIFExCell(2, 4)
-    data = torch.randn(10, 5, 2)
-    state = cell.initial_state(5, "cpu")
-    out, _ = cell(data, state)
+    data = torch.randn(5, 2)
+    out, _ = cell(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 4]))
 
@@ -15,8 +14,7 @@ def test_lif_ex_cell():
 def test_lif_ex_layer():
     layer = lif_ex.LIFExLayer(2, 4)
     data = torch.randn(10, 5, 2)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([10, 5, 4]))
 
@@ -24,7 +22,6 @@ def test_lif_ex_layer():
 def test_lif_ex_feedforward_cell():
     layer = lif_ex.LIFExFeedForwardCell((2, 4))
     data = torch.randn(5, 2, 4)
-    state = layer.initial_state(5, "cpu")
-    out, _ = layer(data, state)
+    out, _ = layer(data)
 
     np.testing.assert_equal(out.shape, np.array([5, 2, 4]))

--- a/norse/torch/module/test/test_lsnn.py
+++ b/norse/torch/module/test/test_lsnn.py
@@ -7,9 +7,8 @@ from nose.tools import raises
 
 def test_lsnn_cell():
     cell = lsnn.LSNNCell(2, 2)
-    state = cell.initial_state(5, "cpu")
     data = torch.ones(5, 2)
-    z, state = cell(data, state)
+    z, state = cell(data)
     np.testing.assert_equal(z.numpy(), np.zeros((5, 2)))
     z, state = cell(data, state)
     np.testing.assert_raises(
@@ -26,25 +25,16 @@ def test_lsnn_cell_param_fail():
     _ = lsnn.LSNNCell()
 
 
-@raises(TypeError)
-def test_lsnn_state_fail():
-    # pylint: disable=E1120
-    cell = lsnn.LSNNCell(2, 10)
-    cell.initial_state()
-
-
 @raises(RuntimeError)
 def test_lsnn_forward_shape_fail():
     cell = lsnn.LSNNCell(2, 10)
-    state = cell.initial_state(5, "cpu")
     data = torch.zeros(10)
-    cell.forward(data, state)
+    cell.forward(data)
 
 
 def test_lsnn_layer():
     layer = lsnn.LSNNLayer(lsnn.LSNNCell, 2, 10)
-    state = layer.initial_state(5, "cpu")
     data = torch.zeros(2, 5, 2)
-    z, s = layer.forward(data, state)
+    z, s = layer.forward(data)
     np.testing.assert_equal(z.detach().numpy(), np.zeros((2, 5, 10)))
     assert isinstance(s, lsnn.LSNNState)

--- a/norse/torch/module/test/test_regularization.py
+++ b/norse/torch/module/test/test_regularization.py
@@ -7,8 +7,7 @@ def regularization_module_test():
     cell = lif.LIFFeedForwardCell((2,))  # 2 -> 4
     r = RegularizationCell()  # Defaults to spike counting
     data = torch.ones(5, 2) + 10  # Batch size of 5
-    s = cell.initial_state(5, device="cpu")
-    z, s = cell(data, s)
+    z, s = cell(data)
     z, rs = r(z, s)
     assert rs == 0
     z, s = cell(data, s)


### PR DESCRIPTION
I solved this by removing all the device parameters from the neuron models and adding a `.to` method for all the `NamedTuple`s encoding state. 
It's slightly hacky but I think it's a solid solution, compared to the alternative of either a) inferring device on the fly (from where?) and b) mapping all tensors to stateful buffers.

Fixes #101 