### PR TITLE
Add Lift module to enable torch.nn.Sequential composition

### DIFF
--- a/norse/torch/module/lift.py
+++ b/norse/torch/module/lift.py
@@ -1,0 +1,61 @@
+from typing import Tuple, Union
+
+
+import torch
+
+
+class Lift(torch.nn.Module):
+    """Lift applies a given torch.nn.Module over
+       a temporal sequence. In other words this module
+       applies the given torch.nn.Module N times, where N
+       is the outer dimension in the provided tensor.
+
+    Parameters:
+        module: Module to apply
+
+    Examples:
+
+        >>> batch_size = 16
+        >>> seq_length = 1000
+        >>> in_channels = 64
+        >>> out_channels = 32
+        >>> conv2d = Lift(torch.nn.Conv2d(in_channels, out_channels, 5, 1))
+        >>> data = torch.randn(seq_length, batch_size, 20, 30)
+        >>> output = conv2d(data)
+
+
+        >>> data = torch.randn(seq_length, batch_size, in_channels, 20, 30)
+        >>> module = torch.nn.Sequential(
+        >>>     Lift(torch.nn.Conv2d(in_channels, out_channels, 5, 1)),
+        >>>     LIFFeedForwardLayer(),
+        >>> )
+        >>> output, _ = module(data)
+    """
+
+    def __init__(self, module: torch.nn.Module):
+        super(Lift, self).__init__()
+        self.lifted_module = module
+
+    def forward(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+    ) -> torch.Tensor:
+        """Apply the module over the input along the 0-th (time) dimension
+        and accumulate the outputs in an output tensor.
+
+        Parameters:
+            x : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]
+
+        Note:
+            If the input is a tuple of two tensors, the second tuple entry will be ignored.
+        """
+        if isinstance(x, tuple):
+            x, _ = x
+
+        T = x.shape[0]
+        outputs = []
+
+        for ts in range(T):
+            out = self.lifted_module(x[ts])
+            outputs += [out]
+
+        return torch.stack(outputs)

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -20,7 +20,7 @@ def test_lif_layer():
 
 
 def test_lif_feedforward_cell():
-    layer = LIFFeedForwardCell((2, 4))
+    layer = LIFFeedForwardCell()
     data = torch.randn(5, 2, 4)
     out, _ = layer(data)
 

--- a/norse/torch/module/test/test_lift.py
+++ b/norse/torch/module/test/test_lift.py
@@ -1,0 +1,37 @@
+import torch
+
+from norse.torch.module.lif import LIFFeedForwardLayer
+from norse.torch.module.lift import Lift
+
+
+def test_lift_conv():
+    batch_size = 16
+    seq_length = 20
+    in_channels = 64
+    out_channels = 32
+    conv2d = Lift(torch.nn.Conv2d(in_channels, out_channels, 5, 1))
+    data = torch.randn(seq_length, batch_size, in_channels, 20, 30)
+    output = conv2d(data)
+
+    assert output.shape == torch.Size([seq_length, batch_size, out_channels, 16, 26])
+
+
+def test_lift_sequential():
+    batch_size = 16
+    seq_length = 20
+    in_channels = 64
+    out_channels = 32
+
+    data = torch.randn(seq_length, batch_size, in_channels, 20, 30)
+    module = torch.nn.Sequential(
+        Lift(torch.nn.Conv2d(in_channels, out_channels, 5, 1)),
+        LIFFeedForwardLayer(),
+    )
+    output, _ = module(data)
+
+    assert output.shape == torch.Size([seq_length, batch_size, out_channels, 16, 26])
+
+
+if __name__ == "__main__":
+    test_lift_conv()
+    test_lift_sequential()

--- a/norse/torch/module/test/test_regularization.py
+++ b/norse/torch/module/test/test_regularization.py
@@ -5,7 +5,7 @@ from norse.torch.module.regularization import RegularizationCell
 
 
 def test_regularization_module():
-    cell = LIFFeedForwardCell((2,))  # 2 -> 4
+    cell = LIFFeedForwardCell()  # 2 -> 4
     r = RegularizationCell()  # Defaults to spike counting
     data = torch.ones(5, 2) + 10  # Batch size of 5
     z, s = cell(data)


### PR DESCRIPTION
This addresses issue #95. Design points to consider: 

- Name of the module is potentially suboptimal. 
- Do we want to support more general input, output combinations
- Currently we hardcode dropping the second element in the tuple, this is meant to seamlessly support composition
  with modules that have forward methods of the kind
```python
forward(x_in : torch.Tensor, s : State) -> (torch.Tensor, State)
```
