### PR TITLE
VGG models lifted to SNN models

### DIFF
--- a/norse/torch/models/LICENSE.vgg
+++ b/norse/torch/models/LICENSE.vgg
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) Soumith Chintala 2016, 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/norse/torch/models/test/test_vgg.py
+++ b/norse/torch/models/test/test_vgg.py
@@ -1,0 +1,29 @@
+import torch
+import norse.torch.models.vgg as vgg
+
+
+def test_vgg11_forward():
+    model = vgg.vgg11()
+    print(model)
+    seq_length = 5
+    batch_size = 2
+    features = 3, 256, 256
+    x = torch.randn(seq_length, batch_size, *features)
+    out = model(x)
+    assert out.shape == torch.Size([seq_length, batch_size, 1000])
+
+
+def test_vgg11_forward_pretrained():
+    model = vgg.vgg11(pretrained=True)
+    print(model)
+    seq_length = 5
+    batch_size = 2
+    features = 3, 256, 256
+    x = torch.randn(seq_length, batch_size, *features)
+    out = model(x)
+    assert out.shape == torch.Size([seq_length, batch_size, 1000])
+
+
+if __name__ == "__main__":
+    test_vgg11_forward()
+    test_vgg11_forward_pretrained()

--- a/norse/torch/models/vgg.py
+++ b/norse/torch/models/vgg.py
@@ -1,0 +1,236 @@
+# adapted from https://github.com/pytorch/vision/blob/master/torchvision/models/vgg.py
+# licensed under BSD 3-Clause License, see LICENSE.vgg for license details
+
+import torch
+import torch.nn as nn
+from torch.hub import load_state_dict_from_url
+from norse.torch.module.lif import LIFFeedForwardLayer
+from norse.torch.module.lift import Lift
+
+__all__ = [
+    "VGG",
+    "vgg11",
+    "vgg11_bn",
+    "vgg13",
+    "vgg13_bn",
+    "vgg16",
+    "vgg16_bn",
+    "vgg19_bn",
+    "vgg19",
+]
+
+
+model_urls = {
+    "vgg11": "https://download.pytorch.org/models/vgg11-bbd30ac9.pth",
+    "vgg13": "https://download.pytorch.org/models/vgg13-c768596a.pth",
+    "vgg16": "https://download.pytorch.org/models/vgg16-397923af.pth",
+    "vgg19": "https://download.pytorch.org/models/vgg19-dcbb9e9d.pth",
+    "vgg11_bn": "https://download.pytorch.org/models/vgg11_bn-6002323d.pth",
+    "vgg13_bn": "https://download.pytorch.org/models/vgg13_bn-abd245e5.pth",
+    "vgg16_bn": "https://download.pytorch.org/models/vgg16_bn-6c64b313.pth",
+    "vgg19_bn": "https://download.pytorch.org/models/vgg19_bn-c79401a0.pth",
+}
+
+
+class VGG(nn.Module):
+    def __init__(self, features, num_classes=1000, init_weights=True):
+        super(VGG, self).__init__()
+        self.features = features
+        self.avgpool = Lift(nn.AdaptiveAvgPool2d((7, 7)))
+        self.classifier = nn.Sequential(
+            Lift(nn.Linear(512 * 7 * 7, 4096)),
+            LIFFeedForwardLayer(),
+            Lift(nn.Dropout()),
+            Lift(nn.Linear(4096, 4096)),
+            LIFFeedForwardLayer(),
+            Lift(nn.Dropout()),
+            Lift(nn.Linear(4096, num_classes)),
+        )
+        if init_weights:
+            self._initialize_weights()
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.avgpool(x)
+        x = torch.flatten(x, 2)
+        x = self.classifier(x)
+        return x
+
+    def _initialize_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.constant_(m.bias, 0)
+
+
+def make_layers(cfg, batch_norm=False):
+    layers = []
+    in_channels = 3
+    for v in cfg:
+        if v == "M":
+            layers += [Lift(nn.MaxPool2d(kernel_size=2, stride=2))]
+        else:
+            conv2d = nn.Conv2d(in_channels, v, kernel_size=3, padding=1)
+            if batch_norm:
+                layers += [Lift(conv2d), Lift(nn.BatchNorm2d(v)), LIFFeedForwardLayer()]
+            else:
+                layers += [Lift(conv2d), LIFFeedForwardLayer()]
+            in_channels = v
+    return nn.Sequential(*layers)
+
+
+cfgs = {
+    "A": [64, "M", 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],
+    "B": [64, 64, "M", 128, 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],
+    "D": [
+        64,
+        64,
+        "M",
+        128,
+        128,
+        "M",
+        256,
+        256,
+        256,
+        "M",
+        512,
+        512,
+        512,
+        "M",
+        512,
+        512,
+        512,
+        "M",
+    ],
+    "E": [
+        64,
+        64,
+        "M",
+        128,
+        128,
+        "M",
+        256,
+        256,
+        256,
+        256,
+        "M",
+        512,
+        512,
+        512,
+        512,
+        "M",
+        512,
+        512,
+        512,
+        512,
+        "M",
+    ],
+}
+
+
+def _vgg(arch, cfg, batch_norm, pretrained, progress, **kwargs):
+    if pretrained:
+        kwargs["init_weights"] = False
+    model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
+
+        snn_state_dict = {}
+
+        # compared to the ANN parameters, the modules are lifted
+        # we modify the state dict accordingly here
+        for key in state_dict:
+            l = key.split(".")
+            l.insert(-1, "lifted_module")
+            new_key = ".".join(l)
+            snn_state_dict[new_key] = state_dict[key]
+
+        model.load_state_dict(snn_state_dict)
+    return model
+
+
+def vgg11(pretrained=False, progress=True, **kwargs):
+    r"""VGG 11-layer model (configuration "A") from
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg11", "A", False, pretrained, progress, **kwargs)
+
+
+def vgg11_bn(pretrained=False, progress=True, **kwargs):
+    r"""VGG 11-layer model (configuration "A") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg11_bn", "A", True, pretrained, progress, **kwargs)
+
+
+def vgg13(pretrained=False, progress=True, **kwargs):
+    r"""VGG 13-layer model (configuration "B")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg13", "B", False, pretrained, progress, **kwargs)
+
+
+def vgg13_bn(pretrained=False, progress=True, **kwargs):
+    r"""VGG 13-layer model (configuration "B") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg13_bn", "B", True, pretrained, progress, **kwargs)
+
+
+def vgg16(pretrained=False, progress=True, **kwargs):
+    r"""VGG 16-layer model (configuration "D")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg16", "D", False, pretrained, progress, **kwargs)
+
+
+def vgg16_bn(pretrained=False, progress=True, **kwargs):
+    r"""VGG 16-layer model (configuration "D") with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg16_bn", "D", True, pretrained, progress, **kwargs)
+
+
+def vgg19(pretrained=False, progress=True, **kwargs):
+    r"""VGG 19-layer model (configuration "E")
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg19", "E", False, pretrained, progress, **kwargs)
+
+
+def vgg19_bn(pretrained=False, progress=True, **kwargs):
+    r"""VGG 19-layer model (configuration 'E') with batch normalization
+    `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vgg("vgg19_bn", "E", True, pretrained, progress, **kwargs)


### PR DESCRIPTION
This is the first of a series of commits that port torchvision models to have intermediate spiking layers (LIFFeedForwardLayers  for now). Some other alternatives could also be considered. We could introduce additional models, where the features are computed  by an ANN and convert only the classifier to an SNN. 

Loading weights from the ANN, pretrained on the ImageNet dataset  also works, but no tests on the classification accuracy has been done. It is unlikely to be high.