### PR TITLE
Example fixes

### DIFF
--- a/norse/task/cartpole.py
+++ b/norse/task/cartpole.py
@@ -2,6 +2,7 @@
 # https://github.com/pytorch/examples/blob/master/reinforcement_learning/reinforce.py
 # which is licensed under the license found in LICENSE.cartpole
 
+import pdb
 import torch
 import numpy as np
 from absl import app
@@ -109,7 +110,7 @@ class LSNNPolicy(torch.nn.Module):
         self.lif_layer = LSNNCell(
             2 * self.state_dim,
             self.hidden_features,
-            p=LSNNParameters(model, alpha=100.0),
+            p=LSNNParameters(method=model, alpha=100.0),
         )
         self.dropout = torch.nn.Dropout(p=0.5)
         self.readout = LICell(self.hidden_features, self.output_features)
@@ -119,8 +120,8 @@ class LSNNPolicy(torch.nn.Module):
 
     def forward(self, x):
         scale = 50
-        _, x_pos = self.constant_current_encoder(torch.nn.functional.relu(scale * x))
-        _, x_neg = self.constant_current_encoder(torch.nn.functional.relu(-scale * x))
+        x_pos = self.constant_current_encoder(torch.nn.functional.relu(scale * x))
+        x_neg = self.constant_current_encoder(torch.nn.functional.relu(-scale * x))
         x = torch.cat([x_pos, x_neg], dim=2)
 
         seq_length, batch_size, _ = x.shape

--- a/norse/task/cartpole.py
+++ b/norse/task/cartpole.py
@@ -2,7 +2,6 @@
 # https://github.com/pytorch/examples/blob/master/reinforcement_learning/reinforce.py
 # which is licensed under the license found in LICENSE.cartpole
 
-import pdb
 import torch
 import numpy as np
 from absl import app

--- a/norse/task/cartpole.py
+++ b/norse/task/cartpole.py
@@ -186,20 +186,21 @@ def main(args):
     FLAGS.append_flags_into_file("flags.txt")
 
     np.random.seed(FLAGS.random_seed)
-    if hasattr(torch, "cuda_is_available"):
-        if torch.cuda_is_available():
-            torch.cuda.manual_seed(FLAGS.random_seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(FLAGS.random_seed)
+
+    device = torch.device(FLAGS.device)
 
     env = gym.make(FLAGS.environment)
     env.reset()
     env.seed(FLAGS.random_seed)
 
     if FLAGS.policy == "ann":
-        policy = ANNPolicy()
+        policy = ANNPolicy().to(device)
     elif FLAGS.policy == "snn":
-        policy = Policy()
+        policy = Policy().to(device)
     elif FLAGS.policy == "lsnn":
-        policy = LSNNPolicy(model=FLAGS.model).to(FLAGS.device)
+        policy = LSNNPolicy(model=FLAGS.model).to(device)
     optimizer = torch.optim.Adam(policy.parameters(), lr=FLAGS.learning_rate)
 
     running_rewards = []
@@ -209,7 +210,7 @@ def main(args):
         state, ep_reward = env.reset(), 0
 
         for t in range(1, 10000):  # Don't infinite loop while learning
-            action = select_action(state, policy, device=FLAGS.device)
+            action = select_action(state, policy, device=device)
             state, reward, done, _ = env.step(action)
             if FLAGS.render:
                 env.render()

--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -255,11 +255,10 @@ def main(args):
     torch.manual_seed(FLAGS.random_seed)
 
     np.random.seed(FLAGS.random_seed)
-    if hasattr(torch, "cuda_is_available"):
-        if torch.cuda_is_available():
-            torch.cuda.manual_seed(FLAGS.random_seed)
-            torch.backends.cudnn.enabled = True
-            torch.backends.cudnn.benchmark = True
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(FLAGS.random_seed)
+        torch.backends.cudnn.enabled = True
+        torch.backends.cudnn.benchmark = True
 
     device = torch.device(FLAGS.device)
 

--- a/norse/task/mnist.py
+++ b/norse/task/mnist.py
@@ -219,11 +219,10 @@ def main(argv):
     torch.manual_seed(FLAGS.random_seed)
 
     np.random.seed(FLAGS.random_seed)
-    if hasattr(torch, "cuda_is_available"):
-        if torch.cuda_is_available():
-            torch.cuda.manual_seed(FLAGS.random_seed)
-            torch.backends.cudnn.enabled = True
-            torch.backends.cudnn.benchmark = True
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(FLAGS.random_seed)
+        torch.backends.cudnn.enabled = True
+        torch.backends.cudnn.benchmark = True
 
     device = torch.device(FLAGS.device)
 


### PR DESCRIPTION
- `torch.cuda.is_available` instead of `torch.cuda_is_available`
- cartpole: write ANN and SNN to device to prevent CUDA error