### PR TITLE
Added torch-like module/functional imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ More information and tasks are available [in our documentation](https://norse.gi
 ### 2.3. Example on using the library: Long short-term spiking neural networks
 The long short-term spiking neural networks from the paper by [G. Bellec, D. Salaj, A. Subramoney, R. Legenstein, and W. Maass (2018)](https://arxiv.org/abs/1803.09574) is one interesting way to apply norse: 
 ```python
-from norse.torch.module.lsnn import LSNNLayer, LSNNCell
+from norse.torch import LSNNLayer, LSNNCell
 # LSNNCell with 2 input neurons and 10 output neurons
 layer = LSNNLayer(LSNNCell, 2, 10)
 # Generate data: 20 timesteps with 8 datapoints per batch for 2 neurons

--- a/norse/__init__.py
+++ b/norse/__init__.py
@@ -17,16 +17,6 @@ except OSError:
 
     setattr(sys.modules[__name__], "IS_OPS_LOADED", False)
 
-from .torch import functional
-from .torch.models import conv
-from .torch.module import lif, lsnn
+from .torch import functional, models, module
 
-__all__ = [
-    "task",
-    "benchmark",
-    "dataset",
-    "functional",
-    "conv",
-    "lif",
-    "lsnn",
-]
+__all__ = ["task", "benchmark", "dataset", "functional", "models", "module"]

--- a/norse/torch/__init__.py
+++ b/norse/torch/__init__.py
@@ -4,7 +4,5 @@ This package contains modules that extends PyTorch with spiking neural
 network functionality.
 """
 
-from . import functional
-from . import module
-
-__all__ = [functional, module]
+from .functional import *
+from .module import *

--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -2,38 +2,89 @@
 Stateless spiking neural network components.
 """
 
-from . import coba_lif
-from . import correlation_sensor
-from . import encode
-from . import heaviside
-from . import leaky_integrator
-from . import lif_correlation
-from . import lif_adex
-from . import lif_ex
-from . import lif_mc_refrac
-from . import lif_mc
-from . import lif
-from . import lsnn
-from . import logical
-from . import regularization
-from . import stdp_sensor
-from . import superspike
+from .coba_lif import coba_lif_feed_forward_step, coba_lif_step
+from .correlation_sensor import correlation_based_update, correlation_sensor_step
+from .encode import (
+    constant_current_lif_encode,
+    euclidean_distance,
+    gaussian_rbf,
+    poisson_encode,
+    population_encode,
+    signed_poisson_encode,
+    spike_latency_encode,
+    spike_latency_lif_encode,
+)
+from .heaviside import heaviside
+from .leaky_integrator import li_feed_forward_step, li_step
+from .lif import lif_current_encoder, lif_feed_forward_step, lif_step
+from .lif_adex import (
+    lif_adex_current_encoder,
+    lif_adex_feed_forward_step,
+    lif_adex_step,
+)
+from .lif_correlation import lif_correlation_step
+from .lif_ex import lif_ex_current_encoder, lif_ex_feed_forward_step, lif_ex_step
+from .lif_mc import lif_mc_feed_forward_step, lif_mc_step
+from .lif_mc_refrac import lif_mc_refrac_feed_forward_step, lif_mc_refrac_step
+from .lif_refrac import lif_refrac_feed_forward_step, lif_refrac_step
+from .logical import logical_and, logical_or, logical_xor
+from .lsnn import lsnn_feed_forward_step, lsnn_step
+from .regularization import regularize_step, spike_accumulator, voltage_accumulator
+from .stdp_sensor import stdp_sensor_step
+from .threshold import (
+    circ_dist_fn,
+    heavi_circ_fn,
+    heavi_erfc_fn,
+    heavi_tanh_fn,
+    heavi_tent_fn,
+    logistic_fn,
+)
 
 __all__ = [
-    coba_lif,
-    correlation_sensor,
-    encode,
-    heaviside,
-    leaky_integrator,
-    lif_adex,
-    lif_correlation,
-    lif_ex,
-    lif_mc,
-    lif_mc_refrac,
-    lif,
-    lsnn,
-    logical,
-    regularization,
-    stdp_sensor,
-    superspike,
+    "coba_lif_feed_forward_step",
+    "coba_lif_step",
+    "correlation_based_update",
+    "correlation_sensor_step",
+    "constant_current_lif_encode",
+    "euclidean_distance",
+    "gaussian_rbf",
+    "poisson_encode",
+    "population_encode",
+    "signed_poisson_encode",
+    "spike_latency_encode",
+    "spike_latency_lif_encode",
+    "heaviside",
+    "li_feed_forward_step",
+    "li_step",
+    "lif_current_encoder",
+    "lif_feed_forward_step",
+    "lif_step",
+    "lif_adex_current_encoder",
+    "lif_adex_feed_forward_step",
+    "lif_adex_step",
+    "lif_correlation_step",
+    "lif_ex_current_encoder",
+    "lif_ex_feed_forward_step",
+    "lif_ex_step",
+    "lif_mc_feed_forward_step",
+    "lif_mc_step",
+    "lif_mc_refrac_feed_forward_step",
+    "lif_mc_refrac_step",
+    "lif_refrac_feed_forward_step",
+    "lif_refrac_step",
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "lsnn_feed_forward_step",
+    "lsnn_step",
+    "regularize_step",
+    "spike_accumulator",
+    "voltage_accumulator",
+    "stdp_sensor_step",
+    "circ_dist_fn",
+    "heavi_circ_fn",
+    "heavi_erfc_fn",
+    "heavi_tanh_fn",
+    "heavi_tent_fn",
+    "logistic_fn",
 ]

--- a/norse/torch/module/__init__.py
+++ b/norse/torch/module/__init__.py
@@ -63,7 +63,7 @@ from .regularization import RegularizationCell
 from .sequential import SequentialState
 
 __all__ = [
-    "CobaLIFState",
+    "CobaLIFCell",
     "CobaLIFState",
     "CobaLIFParameters",
     "ConstantCurrentLIFEncoder",

--- a/norse/torch/module/__init__.py
+++ b/norse/torch/module/__init__.py
@@ -1,21 +1,126 @@
-from . import coba_lif
-from . import leaky_integrator
-from . import lif_adex
-from . import lif_correlation
-from . import lif_ex
-from . import lif_mc_refrac
-from . import lif_mc
-from . import lif
-from . import lsnn
+"""
+Modules for spiking neural network, adhering to the ``torch.nn.Module`` interface.
+"""
+
+from .coba_lif import CobaLIFCell, CobaLIFParameters, CobaLIFState
+from .encode import (
+    ConstantCurrentLIFEncoder,
+    PoissonEncoder,
+    PopulationEncoder,
+    SignedPoissonEncoder,
+    SpikeLatencyEncoder,
+    SpikeLatencyLIFEncoder,
+)
+from .leaky_integrator import LICell, LIFeedForwardCell, LIParameters, LIState
+from .lif import (
+    LIFCell,
+    LIFFeedForwardCell,
+    LIFFeedForwardState,
+    LIFParameters,
+    LIFState,
+    LIFLayer,
+)
+from .lif_adex import (
+    LIFAdExCell,
+    LIFAdExFeedForwardCell,
+    LIFAdExFeedForwardState,
+    LIFAdExParameters,
+    LIFAdExState,
+    LIFAdExLayer,
+)
+from .lif_correlation import (
+    LIFCorrelation,
+    LIFCorrelationParameters,
+    LIFCorrelationState,
+)
+from .lif_ex import (
+    LIFExCell,
+    LIFExFeedForwardCell,
+    LIFExFeedForwardState,
+    LIFExLayer,
+    LIFExParameters,
+    LIFExState,
+)
+from .lif_mc import LIFMCCell
+from .lif_mc_refrac import LIFMCRefracCell
+from .lif_refrac import (
+    LIFRefracCell,
+    LIFRefracFeedForwardCell,
+    LIFRefracFeedForwardState,
+    LIFRefracParameters,
+    LIFRefracState,
+)
+from .lift import Lift
+from .lsnn import (
+    LSNNCell,
+    LSNNFeedForwardCell,
+    LSNNFeedForwardState,
+    LSNNParameters,
+    LSNNState,
+    LSNNLayer,
+)
+from .regularization import RegularizationCell
+from .sequential import SequentialState
 
 __all__ = [
-    coba_lif,
-    leaky_integrator,
-    lif,
-    lif_adex,
-    lif_correlation,
-    lif_ex,
-    lif_mc,
-    lif_mc_refrac,
-    lsnn,
+    "CobaLIFState",
+    "CobaLIFState",
+    "CobaLIFParameters",
+    "ConstantCurrentLIFEncoder",
+    "PoissonEncoder",
+    "PopulationEncoder",
+    "SignedPoissonEncoder",
+    "SpikeLatencyEncoder",
+    "SpikeLatencyLIFEncoder",
+    "LICell",
+    "LIFeedForwardCell",
+    "LIParameters",
+    "LIState",
+    "LIFCell",
+    "LIFLayer",
+    "LIFFeedForwardCell",
+    "LIFFeedForwardState",
+    "LIFParameters",
+    "LIFState",
+    "LIFAdExCell",
+    "LIFAdExFeedForwardCell",
+    "LIFAdExFeedForwardState",
+    "LIFAdExParameters",
+    "LIFAdExState",
+    "LIFAdExLayer",
+    "LIFAdExCell",
+    "LIFAdExFeedForwardCell",
+    "LIFAdExFeedForwardState",
+    "LIFAdExParameters",
+    "LIFAdExState",
+    "LIFCorrelation",
+    "LIFCorrelationParameters",
+    "LIFCorrelationState",
+    "LIFExCell",
+    "LIFExFeedForwardCell",
+    "LIFExFeedForwardState",
+    "LIFExLayer",
+    "LIFExParameters",
+    "LIFExState",
+    "LIFMCCell",
+    "LIFMCRefracCell",
+    "LIFRefracParameters",
+    "LIFRefracState",
+    "LIFMCRefracCell",
+    "LIFRefracParameters",
+    "LIFRefracState",
+    "LIFRefracCell",
+    "LIFRefracFeedForwardCell",
+    "LIFRefracFeedForwardState",
+    "LIFRefracParameters",
+    "LIFRefracState",
+    "Lift",
+    "LSNNCell",
+    "LSNNFeedForwardCell",
+    "LSNNFeedForwardState",
+    "LSNNParameters",
+    "LSNNLayer",
+    "LSNNState",
+    "RegularizationCell",
+    "SequentialState",
 ]

--- a/norse/torch/module/encode.py
+++ b/norse/torch/module/encode.py
@@ -6,7 +6,7 @@ from typing import Union, Callable
 import torch
 
 from norse.torch.functional import lif
-import norse.torch.functional.encode as encode
+from norse.torch.functional import encode
 
 
 class ConstantCurrentLIFEncoder(torch.nn.Module):


### PR DESCRIPTION
In an effort to standardise our API (#121) and better document models (#88), this PR helps easen the code interface by allowing either
```python
import norse
norse.torch.LSNNCell
``` 
or
```python
from norse.torch import LSNNCell
```