### PR TITLE
Added functional lift and corrected lif jit

### DIFF
--- a/norse/torch/functional/lift.py
+++ b/norse/torch/functional/lift.py
@@ -1,0 +1,55 @@
+"""
+A module for lifting neuron activation functions in time.
+Simlar to the :module:`.lift`_ module.
+"""
+
+import torch
+
+
+class _Lifted:
+    """
+    Helper class for the :func:`lift`_ function to allow for pickling.
+    Used in distributed execution, like PyTorch Lightning
+    """
+
+    def __init__(self, activation, p=None):
+        self.activation = activation
+        self.p = p
+
+    def __call__(self, input_tensor, **kwargs):
+        if self.p is not None and "p" not in kwargs:
+            kwargs["p"] = self.p
+
+        state = kwargs.get("state", None)
+        kwargs.pop("state", None)
+        outputs = []
+        for i in input_tensor:
+            if state is not None:
+                out, state = self.activation(i, state=state, **kwargs)
+            else:
+                out, state = self.activation(i, **kwargs)
+            outputs.append(out)
+        return torch.stack(outputs), state
+
+
+def lift(activation, p=None):
+    """
+    Creates a lifted version of the given activation function which
+    applies the activation function in the temporal domain. The returned
+    callable can be applied later as if it was a regular activation function,
+    but the input is now assumed to be a tensor whose first dimension is time.
+
+    Parameters:
+        activation (Callable[[torch.Tensor, Any, Any], Tuple[torch.Tensor, Any]]):
+            The activation function that takes an input tensor, an optional state, and an
+            optional parameter object and returns a tuple of (spiking output, neuron state).
+            The returned spiking output includes the time domain.
+        p (Any): An optional parameter object to hand to the activation function.
+
+    Returns:
+        A :class:`.Callable`_ that, when applied, evaluates the activation function N times,
+        where N is the size of the outer (temporal) dimension. The application will provide
+        a tensor of shape (time, ...).
+    """
+
+    return _Lifted(activation, p)

--- a/norse/torch/functional/test/test_lif.py
+++ b/norse/torch/functional/test/test_lif.py
@@ -46,6 +46,14 @@ def test_lif_feed_forward_step():
         assert torch.allclose(torch.as_tensor(result), s.v, atol=1e-4)
 
 
+def test_lif_feed_forward_step_batch():
+    x = torch.ones(2, 1)
+    s = LIFFeedForwardState(v=torch.zeros(2, 1), i=torch.zeros(2, 1))
+
+    z, s = lif_feed_forward_step(x, s)
+    assert z.shape == (2, 1)
+
+
 def test_lif_feed_forward_step_jit():
     x = torch.ones(10)
     s = LIFFeedForwardState(v=torch.zeros(10), i=torch.zeros(10))

--- a/norse/torch/functional/test/test_lift.py
+++ b/norse/torch/functional/test/test_lift.py
@@ -1,0 +1,89 @@
+import torch
+
+from norse.torch.functional.leaky_integrator import li_step, LIState
+from norse.torch.functional.lif import (
+    lif_step,
+    lif_feed_forward_step,
+    LIFState,
+    LIFFeedForwardState,
+    LIFParameters,
+)
+from norse.torch.functional.lift import lift
+
+
+def test_lift_without_state_or_parameters():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(lif_feed_forward_step)
+    z, s = lifted(data)
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)
+    assert s.i.shape == (2, 1)
+
+
+def test_lift_with_state_without_parameters():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(lif_feed_forward_step)
+    z, s = lifted(
+        data,
+        state=LIFFeedForwardState(torch.zeros_like(data[0]), torch.zeros_like(data[0])),
+    )
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)
+    assert s.i.shape == (2, 1)
+
+
+def test_lift_without_state_with_parameters():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(
+        lif_feed_forward_step, p=LIFParameters(v_th=torch.as_tensor(0.3), method="tanh")
+    )
+    z, s = lifted(data)
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)
+    assert s.i.shape == (2, 1)
+
+
+def test_lift_with_state_and_parameters():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(
+        lif_feed_forward_step, p=LIFParameters(v_th=torch.as_tensor(0.3), method="tanh")
+    )
+    z, s = lifted(
+        data,
+        state=LIFFeedForwardState(torch.zeros_like(data[0]), torch.zeros_like(data[0])),
+    )
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)
+    assert s.i.shape == (2, 1)
+
+
+def test_lift_with_lift_step():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(lif_step)
+    z, s = lifted(
+        data,
+        state=LIFState(
+            v=torch.zeros(2, 1),
+            i=torch.zeros(2, 1),
+            z=torch.zeros(2, 1),
+        ),
+        input_weights=torch.ones(1, 1),
+        recurrent_weights=torch.ones(1, 1),
+    )
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)
+
+
+def test_lift_with_leaky_integrator():
+    data = torch.ones(3, 2, 1)
+    lifted = lift(li_step)
+    z, s = lifted(
+        data,
+        state=LIState(
+            v=torch.zeros(2, 1),
+            i=torch.zeros(2, 1),
+        ),
+        input_weights=torch.ones(1, 1),
+    )
+    assert z.shape == (3, 2, 1)
+    assert s.v.shape == (2, 1)


### PR DESCRIPTION
Added a functional lift that takes a higher-order activation function and runs it in time.

Useful for injecting activation functions without using the module API.

I also fixed a minor problem in the lif_jit where batched inputs wouldn't provide the correct output shape in the first take (with the default state), because broadcasting aren't taking place in the first pass of the lif.