### PR TITLE
Fix LSNNRecurrent Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ output, state = model(data)      # Provides a tuple (tensor (8, 10), neuron stat
 The long short-term spiking neural networks from the paper by [G. Bellec, D. Salaj, A. Subramoney, R. Legenstein, and W. Maass (2018)](https://arxiv.org/abs/1803.09574) is another interesting way to apply norse: 
 ```python
 import torch
-from norse.torch import LSNN
-# LSNNCell with 2 input neurons and 10 output neurons
-layer = LSNN(2, 10)
+from norse.torch import LSNNRecurrent
+# recurrent LSNN network with 2 input neurons and 10 output neurons
+layer = LSNNRecurrent(2, 10)
 # Generate data: 20 timesteps with 8 datapoints per batch for 2 neurons
 data  = torch.zeros(20, 8, 2)
-# Tuple of (output spikes of shape (8, 2), layer state)
+# Tuple of (output spikes of shape (20, 8, 2), layer state)
 output, new_state = layer.forward(data)
 ```
 


### PR DESCRIPTION
Maybe there is a way to automatically check these examples? In any case we should
make sure to check them, when API changes are made.