### PR TITLE
Fixed tensorboard import #215

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Pipfile
 Pipfile.lock
 .pytype/
 htmlcov/
+.venv

--- a/norse/__init__.py
+++ b/norse/__init__.py
@@ -2,6 +2,6 @@
 """
 
 from . import benchmark, dataset, task
-from .torch import functional, models, module, utils
+from .torch import functional, models, module
 
-__all__ = ["task", "benchmark", "dataset", "functional", "models", "module", "utils"]
+__all__ = ["task", "benchmark", "dataset", "functional", "models", "module"]

--- a/norse/torch/__init__.py
+++ b/norse/torch/__init__.py
@@ -7,4 +7,3 @@ network functionality.
 from .functional import *
 from .models import *
 from .module import *
-from .utils import *

--- a/norse/torch/utils/__init__.py
+++ b/norse/torch/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 Utilities for Norse networks in Torch.
 
-The package, and all its subpackages, depends on Matplotlib.
+Packages and subpackages may depend on Matplotlib and Tensorboard.
 """
 
 from .tensorboard import (


### PR DESCRIPTION
Removed imports for `utils` on `norse` and `norse.torch` levels

This eliminates the need to install Tensorboard and fixes #215 