### PR TITLE
Triangular surrogate gradient

### DIFF
--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -1,13 +1,8 @@
-import os
-import datetime
-import uuid
-
 from argparse import ArgumentParser
-from collections import namedtuple
 import torchvision
-import matplotlib.pyplot as plt
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.data
 import pytorch_lightning as pl
@@ -17,8 +12,8 @@ from norse.torch.functional.lif import LIFParameters
 
 
 def label_smoothing_loss(y_hat, y, alpha=0.2):
-    log_probs = torch.nn.functional.log_softmax(y_hat, dim=1, _stacklevel=5)
-    xent = torch.nn.functional.nll_loss(log_probs, y, reduction="none")
+    log_probs = F.log_softmax(y_hat, dim=1, _stacklevel=5)
+    xent = F.nll_loss(log_probs, y, reduction="none")
     KL = -log_probs.mean(dim=1)
     loss = (1 - alpha) * xent + alpha * KL
     return loss.sum()
@@ -40,28 +35,28 @@ class LIFConvNet(pl.LightningModule):
 
         self.features = SequentialState(
             # preparation
-            torch.nn.Conv2d(
+            nn.Conv2d(
                 num_channels, c[0], kernel_size=3, stride=1, padding=1, bias=False
             ),
             LIFCell(p),
             # block 1
-            torch.nn.Conv2d(c[0], c[1], kernel_size=3, stride=1, padding=1, bias=False),
+            nn.Conv2d(c[0], c[1], kernel_size=3, stride=1, padding=1, bias=False),
             LIFCell(p),
-            torch.nn.MaxPool2d(2),
+            nn.MaxPool2d(2),
             # block 2
-            torch.nn.Conv2d(c[1], c[2], kernel_size=3, stride=1, padding=1, bias=False),
+            nn.Conv2d(c[1], c[2], kernel_size=3, stride=1, padding=1, bias=False),
             LIFCell(p),
-            torch.nn.MaxPool2d(2),
+            nn.MaxPool2d(2),
             # block 3
-            torch.nn.Conv2d(c[2], c[3], kernel_size=3, stride=1, padding=1, bias=False),
+            nn.Conv2d(c[2], c[3], kernel_size=3, stride=1, padding=1, bias=False),
             LIFCell(p),
-            torch.nn.MaxPool2d(2),
-            torch.nn.Flatten(),
+            nn.MaxPool2d(2),
+            nn.Flatten(),
         )
 
         self.classification = SequentialState(
             # Classification
-            torch.nn.Linear(4096, 10, bias=False),
+            nn.Linear(4096, 10, bias=False),
             LICell(),
         )
 

--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -187,7 +187,7 @@ __all__ = [
     "heavi_circ_fn",
     "heavi_erfc_fn",
     "heavi_tanh_fn",
-    "heavi_tent_fn",
+    "triangle_fn",
     "logistic_fn",
     "IzhikevichParameters",
     "IzhikevichSpikingBehavior",

--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -81,7 +81,7 @@ from .threshold import (
     heavi_circ_fn,
     heavi_erfc_fn,
     heavi_tanh_fn,
-    heavi_tent_fn,
+    triangle_fn,
     logistic_fn,
 )
 

--- a/norse/torch/functional/test/test_threshold.py
+++ b/norse/torch/functional/test/test_threshold.py
@@ -82,7 +82,7 @@ def test_threshold_backward():
     alpha = 10.0
     x = torch.ones(10)
 
-    methods = ["super", "tanh", "tent", "circ", "heavi_erfc"]
+    methods = ["super", "tanh", "triangle", "circ", "heavi_erfc"]
 
     for method in methods:
         x = torch.ones(10, requires_grad=True)
@@ -101,7 +101,7 @@ def test_threshold_backward():
 def test_threshold():
     alpha = 10.0
 
-    methods = ["super", "heaviside", "tanh", "tent", "circ", "heavi_erfc"]
+    methods = ["super", "heaviside", "tanh", "triangle", "circ", "heavi_erfc"]
 
     for method in methods:
         x = torch.ones(10)
@@ -124,7 +124,7 @@ def test_sign():
         "super",
         "heaviside",
         "tanh",
-        "tent",
+        "triangle",
         "circ",
     ]
 

--- a/norse/torch/functional/threshold.py
+++ b/norse/torch/functional/threshold.py
@@ -1,16 +1,10 @@
-# XXX: temporary for visualization
-import sys
-sys.path.append("norse/torch/functional")
-
 import torch
 import torch.jit
 import numpy as np
 
-import norse
 from norse.torch.functional.heaviside import heaviside
 
 
-# XXX: temporary for visualization
 from superspike import super_fn
 
 superspike_fn = super_fn
@@ -217,27 +211,3 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
 
 def sign(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
     return 2 * threshold(x, method, alpha) - 1
-
-
-# XXX: temporary for visualization
-if __name__ == "__main__":
-    import matplotlib.pyplot as plt
-
-    x = torch.linspace(-5, 5, 1001)
-
-    superspike = 1 / (1 + 100 * x.abs()) ** 2
-    triangle = 0.3 * torch.relu(1 - x.abs())  # same as tent
-    tanh = 1 - (x * 1).tanh().pow(2)
-    circ = -(x.pow(2) / (2 * (1 ** 2 + x.pow(2)).pow(1.5))) + 1 / (2 * (1 ** 2 + x.pow(2)).sqrt()) * 2 * 1
-    erfc = (2 * torch.exp(-(1 * x).pow(2))) / (torch.as_tensor(np.pi).sqrt())
-
-    plt.plot(x.numpy(), superspike.numpy(), label="superspike")
-    plt.plot(x.numpy(), triangle.numpy(), label="triangle")
-    plt.plot(x.numpy(), tanh.numpy(), label="tanh")
-    plt.plot(x.numpy(), circ.numpy(), label="circ")
-    plt.plot(x.numpy(), erfc.numpy(), label="erfc")
-    plt.xlabel("v - thresh")
-    plt.ylabel("grad")
-    plt.grid()
-    plt.legend()
-    plt.show()

--- a/norse/torch/functional/threshold.py
+++ b/norse/torch/functional/threshold.py
@@ -1,3 +1,7 @@
+# XXX: temporary for visualization
+import sys
+sys.path.append("norse/torch/functional")
+
 import torch
 import torch.jit
 import numpy as np
@@ -6,7 +10,8 @@ import norse
 from norse.torch.functional.heaviside import heaviside
 
 
-from .superspike import super_fn
+# XXX: temporary for visualization
+from superspike import super_fn
 
 superspike_fn = super_fn
 
@@ -156,23 +161,37 @@ def circ_dist_fn(x: torch.Tensor, k: float):
     return CircDist.apply(x, k)
 
 
-class HeaviTent(torch.autograd.Function):
+class Triangle(torch.autograd.Function):
+    r"""Triangular/piecewise linear surrogate gradient as in
+
+    S.K. Esser et al., **"Convolutional networks for fast, energy-efficient neuromorphic computing"**,
+    Proceedings of the National Academy of Sciences 113(41), 11441-11446, (2016),
+    `doi:10.1073/pnas.1604850113 <https://www.pnas.org/content/113/41/11441.short>`_
+    G. Bellec et al., **"A solution to the learning dilemma for recurrent networks of spiking neurons"**,
+    Nature Communications 11(1), 3625, (2020),
+    `doi:10.1038/s41467-020-17236-y <https://www.nature.com/articles/s41467-020-17236-y>`_
+    """
+
     @staticmethod
-    def forward(ctx, x, alpha):
-        ctx.alpha = alpha
+    @torch.jit.ignore
+    def forward(ctx, x: torch.Tensor, alpha: float) -> torch.Tensor:
         ctx.save_for_backward(x)
+        ctx.alpha = alpha
         return heaviside(x)
 
     @staticmethod
-    def backward(ctx, dy):
+    @torch.jit.ignore
+    def backward(ctx, grad_output):
         (x,) = ctx.saved_tensors
         alpha = ctx.alpha
-        return torch.relu(1 - torch.abs(x)) * alpha * dy, None
+        grad_input = grad_output.clone()
+        grad = grad_input * alpha * torch.relu(1 - x.abs())
+        return grad, None
 
 
 @torch.jit.ignore
-def heavi_tent_fn(x: torch.Tensor, k: float):
-    return HeaviTent.apply(x, k)
+def triangle_fn(x: torch.Tensor, alpha: float = 0.3) -> torch.Tensor:
+    return Triangle.apply(x, alpha)
 
 
 def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
@@ -180,10 +199,10 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
         return heaviside(x)
     elif method == "super":
         return superspike_fn(x, torch.as_tensor(alpha))
+    elif method == "triangle":
+        return triangle_fn(x, alpha)
     elif method == "tanh":
         return heavi_tanh_fn(x, alpha)
-    elif method == "tent":
-        return heavi_tent_fn(x, alpha)
     elif method == "circ":
         return heavi_circ_fn(x, alpha)
     elif method == "heavi_erfc":
@@ -198,3 +217,27 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
 
 def sign(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
     return 2 * threshold(x, method, alpha) - 1
+
+
+# XXX: temporary for visualization
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
+    x = torch.linspace(-5, 5, 1001)
+
+    superspike = 1 / (1 + 100 * x.abs()) ** 2
+    triangle = 0.3 * torch.relu(1 - x.abs())  # same as tent
+    tanh = 1 - (x * 1).tanh().pow(2)
+    circ = -(x.pow(2) / (2 * (1 ** 2 + x.pow(2)).pow(1.5))) + 1 / (2 * (1 ** 2 + x.pow(2)).sqrt()) * 2 * 1
+    erfc = (2 * torch.exp(-(1 * x).pow(2))) / (torch.as_tensor(np.pi).sqrt())
+
+    plt.plot(x.numpy(), superspike.numpy(), label="superspike")
+    plt.plot(x.numpy(), triangle.numpy(), label="triangle")
+    plt.plot(x.numpy(), tanh.numpy(), label="tanh")
+    plt.plot(x.numpy(), circ.numpy(), label="circ")
+    plt.plot(x.numpy(), erfc.numpy(), label="erfc")
+    plt.xlabel("v - thresh")
+    plt.ylabel("grad")
+    plt.grid()
+    plt.legend()
+    plt.show()

--- a/norse/torch/functional/threshold.py
+++ b/norse/torch/functional/threshold.py
@@ -3,9 +3,7 @@ import torch.jit
 import numpy as np
 
 from norse.torch.functional.heaviside import heaviside
-
-
-from superspike import super_fn
+from norse.torch.functional.superspike import super_fn
 
 superspike_fn = super_fn
 
@@ -205,7 +203,7 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
         raise ValueError(
             f"Attempted to apply threshold function {method}, but no such "
             + "function exist. We currently support heaviside, super, "
-            + "tanh, tent, circ, and heavi_erfc."
+            + "tanh, triangle, circ, and heavi_erfc."
         )
 
 


### PR DESCRIPTION
Solves #229. However, it seems that `HeaviTent` already implemented this surrogate gradient, so maybe I misunderstood the issue. I think this PR could be extended to address #207 as well.

I added some temporary visualization (`python norse/torch/functional/threshold.py`), and it seems several surrogate gradients are quite similar. Maybe this could be cleaned up as well?

Also, should we combine the `superspike.py` and `threshold.py` files into one?