### PR TITLE
Feature quantization

### DIFF
--- a/norse/torch/module/lif.py
+++ b/norse/torch/module/lif.py
@@ -149,16 +149,40 @@ class LIFRecurrentCell(SNNRecurrentCell):
         **kwargs
     ):
         super().__init__(
-            activation=lif_adjoint_step if p.method == "adjoint" else lif_step,
-            activation_sparse=lif_adjoint_step_sparse
+            activation=lif_feed_forward_adjoint_step
             if p.method == "adjoint"
-            else lif_step_sparse,
+            else lif_feed_forward_step,
+            activation_sparse=lif_feed_forward_adjoint_step_sparse
+            if p.method == "adjoint"
+            else lif_feed_forward_step_sparse,
             state_fallback=self.initial_state,
             p=p,
             input_size=input_size,
             hidden_size=hidden_size,
             **kwargs,
         )
+        self.linear_in = torch.nn.Linear(input_size, hidden_size)
+        self.linear_rec = torch.nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, input_tensor, state=None):
+        state = state if state is not None else self.state_fallback(input_tensor)
+        ff_state = LIFFeedForwardState(state.v, state.i)
+        if self.activation_sparse is not None and input_tensor.is_sparse:
+            z, s = self.activation_sparse(
+                input_tensor,
+                ff_state,
+                self.p,
+                self.dt,
+            )
+            return z, LIFState(z, s.v, self.linear_in(s.i) + self.linear_rec(z))
+        else:
+            z, s = self.activation(
+                input_tensor,
+                ff_state,
+                self.p,
+                self.dt,
+            )
+            return z, LIFState(z, s.v, self.linear_in(s.i) + self.linear_rec(z))
 
     def initial_state(self, input_tensor: torch.Tensor) -> LIFState:
         dims = (*input_tensor.shape[:-1], self.hidden_size)

--- a/norse/torch/module/test/test_quantization.py
+++ b/norse/torch/module/test/test_quantization.py
@@ -1,0 +1,33 @@
+"""
+Tests that Norse correctly supports quantization
+"""
+from norse.torch.module.lif import LIFCell, LIFRecurrentCell
+import torch
+
+
+class SNNModel(torch.nn.Module):
+    def __init__(self, snn):
+        super().__init__()
+        self.lin = torch.nn.Linear(2, 1)
+        self.snn = snn
+
+    def forward(self, x, s):
+        return self.snn(self.lin(x), s)
+
+
+def test_quantize_dynamic_cell():
+    m_fp32 = SNNModel(LIFCell())
+    m_int8 = torch.quantization.quantize_dynamic(
+        m_fp32, {torch.nn.Linear, LIFCell}, dtype=torch.qint8
+    )
+    assert isinstance(m_int8.lin, torch.nn.quantized.dynamic.modules.linear.Linear)
+    data = torch.randn(2, 2)
+    m_int8(data)
+
+
+def test_quantized_dynamic_rnn():
+    m_fp32 = SNNModel(LIFRecurrentCell)
+    m_int8 = torch.quantization.quantize_dynamic(
+        m_fp32, {torch.nn.Linear, LIFRecurrentCell}, dtype=torch.qint8
+    )
+    

--- a/norse/torch/module/test/test_quantization.py
+++ b/norse/torch/module/test/test_quantization.py
@@ -1,22 +1,34 @@
 """
 Tests that Norse correctly supports quantization
 """
-from norse.torch.module.lif import LIFCell, LIFRecurrentCell
 import torch
+from norse.torch.module.lif import LIFCell, LIFRecurrentCell, LIFFeedForwardState
 
 
-class SNNModel(torch.nn.Module):
+class SNNModelDynamic(torch.nn.Module):
     def __init__(self, snn):
         super().__init__()
         self.lin = torch.nn.Linear(2, 1)
         self.snn = snn
 
-    def forward(self, x, s):
+    def forward(self, x, s=None):
         return self.snn(self.lin(x), s)
 
 
+class SNNModelStatic(torch.nn.Module):
+    def __init__(self, snn):
+        super().__init__()
+        self.quant = torch.quantization.QuantStub()
+        self.conv = torch.nn.Conv2d(1, 1, 1)
+        self.snn = snn
+        self.dequant = torch.quantization.DeQuantStub()
+
+    def forward(self, x, s=None):
+        return self.dequant(self.snn(self.conv(self.quant(x)), s))
+
+
 def test_quantize_dynamic_cell():
-    m_fp32 = SNNModel(LIFCell())
+    m_fp32 = SNNModelDynamic(LIFCell())
     m_int8 = torch.quantization.quantize_dynamic(
         m_fp32, {torch.nn.Linear, LIFCell}, dtype=torch.qint8
     )
@@ -26,8 +38,12 @@ def test_quantize_dynamic_cell():
 
 
 def test_quantized_dynamic_rnn():
-    m_fp32 = SNNModel(LIFRecurrentCell)
+    m_fp32 = SNNModelDynamic(LIFRecurrentCell(1, 1))
     m_int8 = torch.quantization.quantize_dynamic(
         m_fp32, {torch.nn.Linear, LIFRecurrentCell}, dtype=torch.qint8
     )
-    
+    assert isinstance(m_int8.lin, torch.nn.quantized.dynamic.modules.linear.Linear)
+    assert isinstance(m_int8.snn.linear_in, torch.nn.quantized.dynamic.modules.linear.Linear)
+    assert isinstance(m_int8.snn.linear_rec, torch.nn.quantized.dynamic.modules.linear.Linear)
+    data = torch.randn(2, 2)
+    m_int8(data)


### PR DESCRIPTION
Quantization works well with feed forward dynamics. Unfortunately, we used the functional API to implement recurrent layers, which makes it hard to optimize, since PyTorch doesn't recognize the layers.

1. One approach could be to implement custom quantization primitives, but that would take time. It could, however be necessary if we'd like to fully support quantization on the operations level.
2. Another idea would be to refactor the current recurrent implementations as an `activation` + 2 `linear` layers. 

I like the second version, since that's exactly what a recurrent layer is. We could even go further and remove our recurrent functionals, since I suspect few people are using the functions directly and because it reduces maintainance. The current PR contains a suggestion on how the `LIFRecurrentCell` module could look like - and a test that demonstrates that it works.

I'm eager to hear your opinion @cpehle! May also be interesting for you, @ChFrenkel