### PR TITLE
Add single step poisson encoding and singed poisson encoding

### DIFF
--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -20,8 +20,10 @@ from .encode import (
     euclidean_distance,
     gaussian_rbf,
     poisson_encode,
+    poisson_encode_step,
     population_encode,
     signed_poisson_encode,
+    signed_poisson_encode_step,
     spike_latency_encode,
     spike_latency_lif_encode,
 )

--- a/norse/torch/module/encode.py
+++ b/norse/torch/module/encode.py
@@ -52,12 +52,10 @@ class PoissonEncoder(torch.nn.Module):
     def __init__(self, seq_length: int, f_max: float = 100, dt: float = 0.001):
         """
         Encodes a tensor of input values, which are assumed to be in the
-        range [0,1] (if not signed, [-1,1] if signed)
-        into a tensor of one dimension higher of binary values,
+        range [0,1] into a tensor of one dimension higher of binary values,
         which represent input spikes.
 
         Parameters:
-            input_values (torch.Tensor): Input data tensor with values assumed to be in the interval [0,1].
             sequence_length (int): Number of time steps in the resulting spike train.
             f_max (float): Maximal frequency (in Hertz) which will be emitted.
             dt (float): Integration time step (should coincide with the integration time step used in the model)
@@ -69,6 +67,24 @@ class PoissonEncoder(torch.nn.Module):
 
     def forward(self, x):
         return encode.poisson_encode(x, self.seq_length, f_max=self.f_max, dt=self.dt)
+
+
+class PoissonEncoderStep(torch.nn.Module):
+    def __init__(self, f_max: float = 1000, dt: float = 0.001):
+        """
+        Encodes a tensor of input values, which are assumed to be in the
+        range [0,1] into a tensor of binary values, which represent input spikes.
+
+        Parameters:
+            f_max (float): Maximal frequency (in Hertz) which will be emitted.
+            dt (float): Integration time step (should coincide with the integration time step used in the model)
+        """
+        super(PoissonEncoderStep, self).__init__()
+        self.f_max = f_max
+        self.dt = dt
+
+    def forward(self, x):
+        return encode.poisson_encode_step(x, f_max=self.f_max, dt=self.dt)
 
 
 class PopulationEncoder(torch.nn.Module):
@@ -132,9 +148,8 @@ class SignedPoissonEncoder(torch.nn.Module):
     def __init__(self, seq_length: int, f_max: float = 100, dt: float = 0.001):
         """
         Encodes a tensor of input values, which are assumed to be in the
-        range [-1,1] (if not signed, [-1,1] if signed)
-        into a tensor of one dimension higher of binary values,
-        which represent input spikes.
+        range [-1,1] into a tensor of one dimension higher of values in {-1,0,1},
+        which represent signed input spikes.
 
         Parameters:
             sequence_length (int): Number of time steps in the resulting spike train.
@@ -150,6 +165,25 @@ class SignedPoissonEncoder(torch.nn.Module):
         return encode.signed_poisson_encode(
             x, self.seq_length, f_max=self.f_max, dt=self.dt
         )
+
+
+class SignedPoissonEncoderStep(torch.nn.Module):
+    def __init__(self, f_max: float = 1000, dt: float = 0.001):
+        """
+        Encodes a tensor of input values, which are assumed to be in the
+        range [-1,1] into a tensor of values in {-1,0,1},
+        which represent signed input spikes.
+
+        Parameters:
+            f_max (float): Maximal frequency (in Hertz) which will be emitted.
+            dt (float): Integration time step (should coincide with the integration time step used in the model)
+        """
+        super(SignedPoissonEncoderStep, self).__init__()
+        self.f_max = f_max
+        self.dt = dt
+
+    def forward(self, x):
+        return encode.signed_poisson_encode_step(x, f_max=self.f_max, dt=self.dt)
 
 
 class SpikeLatencyLIFEncoder(torch.nn.Module):

--- a/norse/torch/module/test/test_encode.py
+++ b/norse/torch/module/test/test_encode.py
@@ -10,7 +10,9 @@ from norse.torch.module.encode import (
     ConstantCurrentLIFEncoder,
     SpikeLatencyEncoder,
     PoissonEncoder,
+    PoissonEncoderStep,
     SignedPoissonEncoder,
+    SignedPoissonEncoderStep,
     SpikeLatencyLIFEncoder,
 )
 
@@ -55,12 +57,26 @@ def test_signed_poisson_encoder():
     assert out.shape == torch.Size([seq_length, 10, 10])
 
 
+def test_signed_poisson_encoder_step():
+    encoder = SignedPoissonEncoderStep()
+    x = torch.randn(10, 10)
+    out = encoder(x)
+    assert out.shape == torch.Size([10, 10])
+
+
 def test_poisson_encoder():
     seq_length = 100
     encoder = PoissonEncoder(seq_length=seq_length)
     x = torch.randn(10, 10)
     out = encoder(x)
     assert out.shape == torch.Size([seq_length, 10, 10])
+
+
+def test_poisson_encoder_step():
+    encoder = PoissonEncoderStep()
+    x = torch.randn(10, 10)
+    out = encoder(x)
+    assert out.shape == torch.Size([10, 10])
 
 
 def test_spike_latency_lif_encoder():


### PR DESCRIPTION
This is useful for adding PoissonEncodeStep and SignedPoissonStep to a SequentialState composition like so
```python 
model = SequentialState(
    SignedPoissonStep(), # will create a signed spike vector at each time step, provided the input is in range [-1,1]
    nn.Conv2d(1, 20, 5, 1),      # Convolve from 1 -> 20 channels
    LIFCell(),                   # Spiking activation layer
    nn.MaxPool2d(2, 2),
    nn.Conv2d(20, 50, 5, 1),     # Convolve from 20 -> 50 channels
    LIFCell(),
    nn.MaxPool2d(2, 2),
    nn.Flatten(),                # Flatten to 800 units
    nn.Linear(800, 10),
    LICell(),                    # Non-spiking integrator layer
)
```