### PR TITLE
Threshold module

### DIFF
--- a/norse/torch/functional/surrogates.py
+++ b/norse/torch/functional/surrogates.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+__all__ = ["erfc", "tanh", "logistic", "circ", "superspike", "triangle"]
+
+
+def erfc(x: torch.Tensor, alpha: float, beta: Optional[float]) -> torch.Tensor:
+    r"""Approximation of the heaviside step function as
+
+    .. math::
+        h(x,\alpha) = \frac{1}{2} + \frac{1}{2} \text{erfc}(\alpha x)
+
+    where erfc is the error function.
+    """
+    return (2 * torch.exp(-(alpha * x).pow(2))) / (torch.as_tensor(np.pi).sqrt())
+
+
+def tanh(x: torch.Tensor, alpha: float, beta: Optional[float]) -> torch.Tensor:
+    r"""Approximation of the heaviside step function as
+
+    .. math::
+        h(x,\alpha) = \frac{1}{2} + \frac{1}{2} \text{tanh}(\alpha x)
+    """
+    return 1 - (x * alpha).tanh().pow(2)
+
+
+def logistic(x: torch.Tensor, alpha: float, beta: Optional[float]) -> torch.Tensor:
+    r"""Probalistic approximation of the heaviside step function as
+
+    .. math::
+        z \sim p(\frac{1}{2} + \frac{1}{2} \text{tanh}(\alpha x))
+    """
+    return 1 - (x * alpha).tanh().pow(2)
+
+
+def circ(x: torch.Tensor, alpha: float, beta: Optional[float]) -> torch.Tensor:
+    r"""Approximation of the heaviside step function as
+
+    .. math::
+        h(x,\alpha) = \frac{1}{2} + \frac{1}{2} \
+        \frac{x}{(x^2 + \alpha^2)^{1/2}}
+    """
+
+    return -(x.pow(2) / (2 * (alpha ** 2 + x.pow(2)).pow(1.5))) + 1 / (2 * (alpha ** 2 + x.pow(2)).sqrt()) * 2 * alpha
+
+
+def superspike(x: torch.Tensor, alpha: float, beta: Optional[float]) -> torch.Tensor:
+    r"""SuperSpike surrogate gradient as described in Section 3.3.2 of
+
+    F. Zenke, S. Ganguli, **"SuperSpike: Supervised Learning in Multilayer Spiking Neural Networks"**,
+    Neural Computation 30, 1514–1541 (2018),
+    `doi:10.1162/neco_a_01086 <https://www.mitpressjournals.org/doi/full/10.1162/neco_a_01086>`_
+    """
+    return 1 / (alpha * torch.abs(x) + 1).pow(2)
+
+
+def triangle(x: torch.Tensor, alpha: float, beta: float) -> torch.Tensor:
+    r"""Triangular/piecewise linear surrogate gradient as in
+
+    S.K. Esser et al., **"Convolutional networks for fast, energy-efficient neuromorphic computing"**,
+    Proceedings of the National Academy of Sciences 113(41), 11441-11446, (2016),
+    `doi:10.1073/pnas.1604850113 <https://www.pnas.org/content/113/41/11441.short>`_
+    G. Bellec et al., **"A solution to the learning dilemma for recurrent networks of spiking neurons"**,
+    Nature Communications 11(1), 3625, (2020),
+    `doi:10.1038/s41467-020-17236-y <https://www.nature.com/articles/s41467-020-17236-y>`_
+    """
+    return beta * torch.relu(1 - alpha * x.abs())

--- a/norse/torch/functional/threshold.py
+++ b/norse/torch/functional/threshold.py
@@ -1,3 +1,7 @@
+# XXX: temporary for visualization
+import sys
+sys.path.append("norse/torch/functional")
+
 import torch
 import torch.jit
 import numpy as np
@@ -6,7 +10,8 @@ import norse
 from norse.torch.functional.heaviside import heaviside
 
 
-from .superspike import super_fn
+# XXX: temporary for visualization
+from superspike import super_fn
 
 superspike_fn = super_fn
 
@@ -156,23 +161,37 @@ def circ_dist_fn(x: torch.Tensor, k: float):
     return CircDist.apply(x, k)
 
 
-class HeaviTent(torch.autograd.Function):
+class Triangle(torch.autograd.Function):
+    r"""Triangular/piecewise linear surrogate gradient as in
+
+    S.K. Esser et al., **"Convolutional networks for fast, energy-efficient neuromorphic computing"**,
+    Proceedings of the National Academy of Sciences 113(41), 11441-11446, (2016),
+    `doi:10.1073/pnas.1604850113 <https://www.pnas.org/content/113/41/11441.short>`_
+    G. Bellec et al., **"A solution to the learning dilemma for recurrent networks of spiking neurons"**,
+    Nature Communications 11(1), 3625, (2020),
+    `doi:10.1038/s41467-020-17236-y <https://www.nature.com/articles/s41467-020-17236-y>`_
+    """
+
     @staticmethod
-    def forward(ctx, x, alpha):
-        ctx.alpha = alpha
+    @torch.jit.ignore
+    def forward(ctx, x: torch.Tensor, alpha: float) -> torch.Tensor:
         ctx.save_for_backward(x)
+        ctx.alpha = alpha
         return heaviside(x)
 
     @staticmethod
-    def backward(ctx, dy):
+    @torch.jit.ignore
+    def backward(ctx, grad_output):
         (x,) = ctx.saved_tensors
         alpha = ctx.alpha
-        return torch.relu(1 - torch.abs(x)) * alpha * dy, None
+        grad_input = grad_output.clone()
+        grad = grad_input * alpha * torch.relu(1 - x.abs())
+        return grad, None
 
 
 @torch.jit.ignore
-def heavi_tent_fn(x: torch.Tensor, k: float):
-    return HeaviTent.apply(x, k)
+def triangle_fn(x: torch.Tensor, alpha: float = 0.3) -> torch.Tensor:
+    return Triangle.apply(x, alpha)
 
 
 def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
@@ -180,10 +199,10 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
         return heaviside(x)
     elif method == "super":
         return superspike_fn(x, torch.as_tensor(alpha))
+    elif method == "triangle":
+        return triangle_fn(x, alpha)
     elif method == "tanh":
         return heavi_tanh_fn(x, alpha)
-    elif method == "tent":
-        return heavi_tent_fn(x, alpha)
     elif method == "circ":
         return heavi_circ_fn(x, alpha)
     elif method == "heavi_erfc":
@@ -198,3 +217,27 @@ def threshold(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
 
 def sign(x: torch.Tensor, method: str, alpha: float) -> torch.Tensor:
     return 2 * threshold(x, method, alpha) - 1
+
+
+# XXX: temporary for visualization
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
+    x = torch.linspace(-5, 5, 1001)
+
+    superspike = 1 / (1 + 100 * x.abs()) ** 2
+    triangle = 0.3 * torch.relu(1 - x.abs())  # same as tent
+    tanh = 1 - (x * 1).tanh().pow(2)
+    circ = -(x.pow(2) / (2 * (1 ** 2 + x.pow(2)).pow(1.5))) + 1 / (2 * (1 ** 2 + x.pow(2)).sqrt()) * 2 * 1
+    erfc = (2 * torch.exp(-(1 * x).pow(2))) / (torch.as_tensor(np.pi).sqrt())
+
+    plt.plot(x.numpy(), superspike.numpy(), label="superspike")
+    plt.plot(x.numpy(), triangle.numpy(), label="triangle")
+    plt.plot(x.numpy(), tanh.numpy(), label="tanh")
+    plt.plot(x.numpy(), circ.numpy(), label="circ")
+    plt.plot(x.numpy(), erfc.numpy(), label="erfc")
+    plt.xlabel("v - thresh")
+    plt.ylabel("grad")
+    plt.grid()
+    plt.legend()
+    plt.show()


### PR DESCRIPTION
Attempts to solve #207. I started on implementing a base threshold module, which supports different kinds of surrogate gradients. However, then I noticed that some spiking functions were probabilistic, and I got stuck on trying to find a way to accomodate `forward()` functions with different arguments. Same goes a bit for the `backward()` ones: there might be some surrogates that have more parameters than only `alpha`.