### PR TITLE
Remove trailing symbol in notebook examples link.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ as demonstrated in the [PyTorch Lightning MNIST task variant](https://github.com
 python -m norse.task.mnist_pl --gpus=4
 ```
 
-Read more in our {ref}`page-spiking` and visit our [Jupyter Notebook examples](https://github.com/norse/notebooks>). 
+Read more in our {ref}`page-spiking` and visit our [Jupyter Notebook examples](https://github.com/norse/notebooks). 
 
 ## Advanced uses and opimizations
 


### PR DESCRIPTION
There was a trailing less-than in the notebook examples link in docs/index.md.

I thought of fixing it since it is directly on the landing page of the docs and might be a minor inconvenience for people checking out Norse for the first time. :)