### PR TITLE
Added a spike time decoder

### DIFF
--- a/norse/torch/functional/__init__.py
+++ b/norse/torch/functional/__init__.py
@@ -31,6 +31,7 @@ from .correlation_sensor import (
     correlation_based_update,
     correlation_sensor_step,
 )
+from .decode import sum_decode, spike_time_decode
 from .encode import (
     constant_current_lif_encode,
     euclidean_distance,
@@ -171,6 +172,9 @@ __all__ = [
     "CorrelationSensorState",
     "correlation_based_update",
     "correlation_sensor_step",
+    # Decoders
+    "sum_decode",
+    "spike_time_decode",
     # Encoders
     "constant_current_lif_encode",
     "euclidean_distance",

--- a/norse/torch/functional/decode.py
+++ b/norse/torch/functional/decode.py
@@ -17,6 +17,32 @@ def sum_decode(tensor: torch.Tensor, dimension: int = 0):
     return tensor.sum(dimension)
 
 
+class SpikeTimeDecode(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, i: torch.Tensor):
+        if i.is_sparse:
+            sparse = i.coalesce()
+        else:
+            sparse = i.to_sparse().coalesce()
+        ctx.save_for_backward(sparse, torch.as_tensor(i.is_sparse))
+        indices = sparse.indices().float()
+        if i.requires_grad:
+            indices.requires_grad = True
+        return indices
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        result, was_sparse = ctx.saved_tensors
+        values = result.values() * grad_output.mean(0)  # Mean over index dimension
+        sparse = torch.sparse_coo_tensor(
+            indices=result.indices(), values=values, size=result.size()
+        )
+        if was_sparse:
+            return sparse
+        else:
+            return sparse.to_dense()
+
+
 def spike_time_decode(tensor: torch.Tensor):
     """
     Reduces an input tensor to the timestamp indices of spike occurences.
@@ -26,23 +52,25 @@ def spike_time_decode(tensor: torch.Tensor):
     Example:
     >>> x = torch.tensor([0, 0, 0, 1, 0])
     >>> spike_time_decode(x)
-    tensor([[3]])
+    >>> # tensor([[3]])
 
     >>> x = torch.tensor([[0, 1], [1, 1], [0, 0]])
     >>> spike_time_decode(x)
-    tensor([[0, 1, 1],
-            [1, 0, 1]])
+    >>> # tensor([[0, 1, 1],
+    >>> #         [1, 0, 1]])
+
+    >>> x = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 0, 1]], dtype=torch.float32, requires_grad=True)
+    >>> spike_time_decode(x)
+    >>> # torch.tensor([[0, 1, 1, 1, 2],
+    >>> #               [1, 0, 1, 2, 2]])
 
     Arguments:
         tensor (torch.Tensor): A tensor of spikes (1's)
 
     Returns:
         A tensor of shape (``ndims``, ``nvalues``) where ``ndims`` is the number of
-        dimensions in the tensor and ``nvalues`` are the number of spike-events that
+        dimensions in the tensor and ``nvalues`` are the spike-events that
         occured in the input tensor.
+        Note that the returned tensor uses floats to support the flow of gradients.
     """
-    if tensor.is_sparse:
-        sparse = tensor
-    else:
-        sparse = tensor.to_sparse()
-    return sparse.coalesce().indices()
+    return SpikeTimeDecode.apply(tensor)

--- a/norse/torch/functional/decode.py
+++ b/norse/torch/functional/decode.py
@@ -15,3 +15,34 @@ def sum_decode(tensor: torch.Tensor, dimension: int = 0):
     Sums the input tensor in the first dimension by default.
     """
     return tensor.sum(dimension)
+
+
+def spike_time_decode(tensor: torch.Tensor):
+    """
+    Reduces an input tensor to the timestamp indices of spike occurences.
+    Put differently, this decoder extracts the indices of spike activities
+    so as to operate on time indices instead of spike patterns.
+
+    Example:
+    >>> x = torch.tensor([0, 0, 0, 1, 0])
+    >>> spike_time_decode(x)
+    tensor([[3]])
+
+    >>> x = torch.tensor([[0, 1], [1, 1], [0, 0]])
+    >>> spike_time_decode(x)
+    tensor([[0, 1, 1],
+            [1, 0, 1]])
+
+    Arguments:
+        tensor (torch.Tensor): A tensor of spikes (1's)
+
+    Returns:
+        A tensor of shape (``ndims``, ``nvalues``) where ``ndims`` is the number of
+        dimensions in the tensor and ``nvalues`` are the number of spike-events that
+        occured in the input tensor.
+    """
+    if tensor.is_sparse:
+        sparse = tensor
+    else:
+        sparse = tensor.to_sparse()
+    return sparse.coalesce().indices()

--- a/norse/torch/functional/test/test_decode.py
+++ b/norse/torch/functional/test/test_decode.py
@@ -1,7 +1,19 @@
 import torch
-from norse.torch.functional.decode import sum_decode
+from norse.torch.functional.decode import spike_time_decode, sum_decode
 
 
 def test_sum_decode():
     x = sum_decode(torch.ones(10, 3))
     assert torch.allclose(x, torch.ones(3) * 10)
+
+
+def test_spike_time_decode():
+    x = torch.tensor([[0, 1], [1, 1], [0, 0]])
+    y = torch.tensor([[0, 1, 1], [1, 0, 1]])
+    assert torch.all(torch.eq(spike_time_decode(x), y))
+
+
+def test_spike_time_decode_sparse():
+    x = torch.tensor([0, 1, 0, 0, 0, 1]).to_sparse()
+    y = torch.tensor([[1, 5]])
+    assert torch.all(torch.eq(spike_time_decode(x), y))

--- a/norse/torch/functional/test/test_decode.py
+++ b/norse/torch/functional/test/test_decode.py
@@ -6,6 +6,7 @@ def test_sum_decode():
     x = sum_decode(torch.ones(10, 3))
     assert torch.allclose(x, torch.ones(3) * 10)
 
+
 def test_decode_sparse_retain_grad():
     x = torch.tensor([[0, 1], [1, 1], [0, 0]], dtype=torch.float32)
     assert not spike_time_decode(x).requires_grad
@@ -13,13 +14,17 @@ def test_decode_sparse_retain_grad():
     x = torch.tensor([[0, 1], [1, 1], [0, 0]], dtype=torch.float32, requires_grad=True)
     assert spike_time_decode(x).requires_grad
 
+
 def test_spike_time_decode():
-    x = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 0, 1]], dtype=torch.float32, requires_grad=True)
+    x = torch.tensor(
+        [[0, 1, 0], [1, 1, 1], [0, 0, 1]], dtype=torch.float32, requires_grad=True
+    )
     y = torch.tensor([[0, 1, 1, 1, 2], [1, 0, 1, 2, 2]])
     out = spike_time_decode(x)
     assert torch.all(torch.eq(out, y))
     out.sum().backward()
     assert torch.all(torch.eq(x, x.grad))
+
 
 def test_spike_time_decode_sparse():
     x = torch.tensor([0, 1, 0, 0, 0, 1], dtype=torch.float32, requires_grad=True)

--- a/norse/torch/functional/test/test_decode.py
+++ b/norse/torch/functional/test/test_decode.py
@@ -6,14 +6,25 @@ def test_sum_decode():
     x = sum_decode(torch.ones(10, 3))
     assert torch.allclose(x, torch.ones(3) * 10)
 
+def test_decode_sparse_retain_grad():
+    x = torch.tensor([[0, 1], [1, 1], [0, 0]], dtype=torch.float32)
+    assert not spike_time_decode(x).requires_grad
+
+    x = torch.tensor([[0, 1], [1, 1], [0, 0]], dtype=torch.float32, requires_grad=True)
+    assert spike_time_decode(x).requires_grad
 
 def test_spike_time_decode():
-    x = torch.tensor([[0, 1], [1, 1], [0, 0]])
-    y = torch.tensor([[0, 1, 1], [1, 0, 1]])
-    assert torch.all(torch.eq(spike_time_decode(x), y))
-
+    x = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 0, 1]], dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([[0, 1, 1, 1, 2], [1, 0, 1, 2, 2]])
+    out = spike_time_decode(x)
+    assert torch.all(torch.eq(out, y))
+    out.sum().backward()
+    assert torch.all(torch.eq(x, x.grad))
 
 def test_spike_time_decode_sparse():
-    x = torch.tensor([0, 1, 0, 0, 0, 1]).to_sparse()
+    x = torch.tensor([0, 1, 0, 0, 0, 1], dtype=torch.float32, requires_grad=True)
     y = torch.tensor([[1, 5]])
-    assert torch.all(torch.eq(spike_time_decode(x), y))
+    out = spike_time_decode(x.to_sparse())
+    assert torch.all(torch.eq(out, y))
+    out.sum().backward()
+    assert torch.all(torch.eq(x, x.grad))

--- a/norse/torch/module/__init__.py
+++ b/norse/torch/module/__init__.py
@@ -4,6 +4,7 @@ Modules for spiking neural network, adhering to the ``torch.nn.Module`` interfac
 
 from .coba_lif import CobaLIFCell, CobaLIFParameters, CobaLIFState
 from .conv import LConv2d
+from .decode import SpikeTimeDecoder
 from .encode import (
     ConstantCurrentLIFEncoder,
     PoissonEncoder,
@@ -85,6 +86,7 @@ __all__ = [
     "SignedPoissonEncoder",
     "SpikeLatencyEncoder",
     "SpikeLatencyLIFEncoder",
+    "SpikeTimeDecoder",
     "LI",
     "LICell",
     "LILinearCell",

--- a/norse/torch/module/decode.py
+++ b/norse/torch/module/decode.py
@@ -15,17 +15,27 @@ class SpikeTimeDecoder(torch.nn.Module):
 
     Example:
     >>> x = torch.tensor([0, 0, 0, 1, 0])
-    >>> SpikeTimeDecoder()(x)
-    tensor([[3]])
+    >>> spike_time_decode(x)
+    >>> # tensor([[3]])
 
-    >>> import norse.torch as nt
-    >>> model = nt.SequentialState(
-    >>>     nt.LIFCell(),
-    >>>     nt.SpikeTimeDecoder()
-    >>> )
-    >>> x, _ = model(torch.ones(10, 2))
-    tensor([[6, 6, 9, 9]
-            [0, 1, 0, 1]])
+    >>> x = torch.tensor([[0, 1], [1, 1], [0, 0]])
+    >>> spike_time_decode(x)
+    >>> # tensor([[0, 1, 1],
+    >>> #         [1, 0, 1]])
+
+    >>> x = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 0, 1]], dtype=torch.float32, requires_grad=True)
+    >>> spike_time_decode(x)
+    >>> # torch.tensor([[0, 1, 1, 1, 2],
+    >>> #               [1, 0, 1, 2, 2]])
+
+    Arguments:
+        tensor (torch.Tensor): A tensor of spikes (1's)
+
+    Returns:
+        A tensor of shape (``ndims``, ``nvalues``) where ``ndims`` is the number of
+        dimensions in the tensor and ``nvalues`` are the spike-events that
+        occured in the input tensor.
+        Note that the returned tensor uses floats to support the flow of gradients.
     """
 
     @staticmethod

--- a/norse/torch/module/decode.py
+++ b/norse/torch/module/decode.py
@@ -28,5 +28,6 @@ class SpikeTimeDecoder(torch.nn.Module):
             [0, 1, 0, 1]])
     """
 
-    def forward(self, input_tensor: torch.Tensor):
+    @staticmethod
+    def forward(input_tensor: torch.Tensor):
         return spike_time_decode(input_tensor)

--- a/norse/torch/module/decode.py
+++ b/norse/torch/module/decode.py
@@ -1,0 +1,32 @@
+"""
+Decoders as torch modules.
+"""
+
+import torch
+
+from norse.torch.functional.decode import spike_time_decode
+
+
+class SpikeTimeDecoder(torch.nn.Module):
+    """
+    Reduces an input tensor to the timestamp indices of spike occurences.
+    Put differently, this decoder extracts the indices of spike activities
+    so as to operate on time indices instead of spike patterns.
+
+    Example:
+    >>> x = torch.tensor([0, 0, 0, 1, 0])
+    >>> SpikeTimeDecoder()(x)
+    tensor([[3]])
+
+    >>> import norse.torch as nt
+    >>> model = nt.SequentialState(
+    >>>     nt.LIFCell(),
+    >>>     nt.SpikeTimeDecoder()
+    >>> )
+    >>> x, _ = model(torch.ones(10, 2))
+    tensor([[6, 6, 9, 9]
+            [0, 1, 0, 1]])
+    """
+
+    def forward(self, input_tensor: torch.Tensor):
+        return spike_time_decode(input_tensor)

--- a/norse/torch/module/encode.py
+++ b/norse/torch/module/encode.py
@@ -1,5 +1,5 @@
 """
-Stateful encoders as torch modules.
+Encoders as torch modules.
 """
 
 from typing import Union, Callable

--- a/norse/torch/module/lif_mc_refrac.py
+++ b/norse/torch/module/lif_mc_refrac.py
@@ -23,7 +23,7 @@ class LIFMCRefracRecurrentCell(SNNRecurrentCell):
     ):
         # pytype: disable=wrong-arg-types
         super().__init__(
-            activation=None,
+            activation=lif_mc_refrac_step,
             state_fallback=self.initial_state,
             input_size=input_size,
             hidden_size=hidden_size,

--- a/norse/torch/module/test/test_decode.py
+++ b/norse/torch/module/test/test_decode.py
@@ -7,7 +7,7 @@ from norse.torch.module.sequential import SequentialState
 
 def test_spike_time_decode():
     x = torch.tensor([[0, 1], [1, 1], [0, 0]])
-    y = torch.tensor([[0, 1, 1], [1, 0, 1]])
+    y = torch.tensor([[0, 1, 1], [1, 0, 1]]).float()
     assert torch.allclose(SpikeTimeDecoder()(x), y)
 
 

--- a/norse/torch/module/test/test_decode.py
+++ b/norse/torch/module/test/test_decode.py
@@ -1,0 +1,17 @@
+import torch
+
+from norse.torch.module.decode import SpikeTimeDecoder
+from norse.torch.module.lif import LIF
+from norse.torch.module.sequential import SequentialState
+
+
+def test_spike_time_decode():
+    x = torch.tensor([[0, 1], [1, 1], [0, 0]])
+    y = torch.tensor([[0, 1, 1], [1, 0, 1]])
+    assert torch.allclose(SpikeTimeDecoder()(x), y)
+
+
+def test_spike_time_decode_sequential():
+    model = SequentialState(LIF(), SpikeTimeDecoder())
+    x, _ = model(torch.ones(10, 2))
+    assert torch.all(torch.eq(x, torch.tensor([[6, 6, 9, 9], [0, 1, 0, 1]])))


### PR DESCRIPTION
This decoder addresses #250 by computing the indices of the spike values (1's) in a given tensor. 

The returned tensor has shape (`ndim`, `nvalues`), e. g.

```python
x = torch.tensor([0, 0, 0, 1, 0])
SpikeTimeDecoder()(x)           
    # tensor([[3]])
```

```python
import norse.torch as nt
model = nt.SequentialState(
    LIFCell(),
    nt.SpikeTimeDecoder()
)
x, _ = model(torch.ones(10, 2))
   # tensor([[6, 6, 9, 9]
   #         [0, 1, 0, 1]])```
