### PR TITLE
Fixed issue with sequential forward hooks

### DIFF
--- a/norse/torch/module/sequential.py
+++ b/norse/torch/module/sequential.py
@@ -83,10 +83,11 @@ class SequentialState(torch.nn.Sequential):
 
     def remove_forward_state_hooks(self):
         """
-        Disables the forward state hooks, registered in :meth:`register_forward_state_hooks`_.
+        Disables and discards the forward state hooks, registered in :meth:`register_forward_state_hooks`_.
         """
         for handle in self.forward_state_hooks:
             handle.remove()
+        self.forward_state_hooks.clear()
 
     def forward(self, input_tensor: torch.Tensor, state: Union[list, None] = None):
         """

--- a/norse/torch/module/test/test_sequential.py
+++ b/norse/torch/module/test/test_sequential.py
@@ -128,6 +128,7 @@ def test_sequential_forward_state_hook():
     model(data, s)
     assert hasattr(states[0], "v")  # isinstance is broken for namedtuple
     model.remove_forward_state_hooks()
+    assert len(model.forward_state_hooks) == 0
     model(data, s)
     assert len(spikes) == 4
 


### PR DESCRIPTION
Deletes registered hooks in the sequential module upon calling `remove_forward_state_hooks`.