### PR TITLE
Fixed Python and Torch version in Dockerfiles

### DIFF
--- a/publish/Dockerfile
+++ b/publish/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.9-slim
 
 RUN apt update && apt install -y python3-pip build-essential
 RUN rm -rf /var/lib/apt/lists/
@@ -8,4 +8,5 @@ WORKDIR /norse
 COPY . .
 
 RUN pip3 install --upgrade pip
+RUN pip3 install torch==1.9.1+cpu torchvision==0.10.1+cpu torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip3 install -e .

--- a/publish/Dockerfile.cuda
+++ b/publish/Dockerfile.cuda
@@ -8,4 +8,5 @@ WORKDIR /norse
 COPY . .
 
 RUN pip3 install --upgrade pip
+RUN pip3 install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip3 install -e .


### PR DESCRIPTION
Torch failed to build via pip in Python3.10, so I reverted to 3.9 and fixed PyTorch version.