### PR TITLE
Added record_states flag to SNNs

### DIFF
--- a/norse/torch/module/test/test_snn.py
+++ b/norse/torch/module/test/test_snn.py
@@ -8,7 +8,8 @@ from norse.torch.functional.lif import (
     LIFState,
     LIFParameters,
 )
-from norse.torch.module import lif, snn
+from norse.torch.functional.lif_refrac import LIFRefracState
+from norse.torch.module import lif, snn, lif_refrac
 
 
 class MockParams(NamedTuple):
@@ -156,7 +157,7 @@ def test_snn_repr():
 def test_snn_record_state():
     n = snn.SNN(
         lif_feed_forward_step,
-        lambda x: LIFFeedForwardState(v=torch.zeros(3), i=torch.zeros(3)),
+        lambda x: LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1)),
         p=LIFParameters(v_th=torch.as_tensor(0.1)),
         record_states=False,
     )
@@ -165,37 +166,55 @@ def test_snn_record_state():
 
     n = snn.SNN(
         lif_feed_forward_step,
-        lambda x: LIFFeedForwardState(v=torch.zeros(3), i=torch.zeros(3)),
+        lambda x: LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1)),
         p=LIFParameters(v_th=torch.as_tensor(0.1)),
         record_states=True,
     )
     _, y = n(torch.zeros(3, 1))
-    assert isinstance(y, list)
+    assert isinstance(y, LIFFeedForwardState)
+    assert y.v.shape == (3, 1)
+    assert y.i.shape == (3, 1)
 
 
 def test_snn_recurrent_record_state():
     n = snn.SNNRecurrent(
         lif_step,
-        lambda x: LIFState(v=torch.zeros(3), i=torch.zeros(3), z=torch.ones(3)),
+        lambda x: LIFState(v=torch.zeros(4), i=torch.zeros(4), z=torch.ones(4)),
         2,
-        3,
+        4,
         p=LIFParameters(v_th=torch.as_tensor(0.1)),
         record_states=False,
     )
     _, y = n(torch.zeros(3, 2))
     assert isinstance(y, LIFState)
+    assert y.v.shape == (4,)
+    assert y.i.shape == (4,)
+    assert y.z.shape == (4,)
 
     n = snn.SNNRecurrent(
         lif_step,
-        lambda x: LIFState(v=torch.zeros(3), i=torch.zeros(3), z=torch.ones(3)),
+        lambda x: LIFState(v=torch.zeros(4), i=torch.zeros(4), z=torch.ones(4)),
         2,
-        3,
+        4,
         p=LIFParameters(v_th=torch.as_tensor(0.1)),
         record_states=True,
     )
     _, y = n(torch.zeros(3, 2))
-    assert isinstance(y, list)
+    assert isinstance(y, LIFState)
+    assert y.v.shape == (3, 4)
+    assert y.i.shape == (3, 4)
+    assert y.z.shape == (3, 4)
 
+def test_snn_record_nested_state():
+    n = lif_refrac.LIFRefracRecurrent(
+        2,
+        4,
+        record_states=True,
+    )
+    _, y = n(torch.zeros(3, 2))
+    assert isinstance(y, LIFRefracState)
+    assert isinstance(y.lif, LIFState)
+    assert y.rho.shape == (3, 4)
 
 def test_snn_recurrent_repr():
     n = snn.SNNRecurrent(None, None, 1, 2, MockParams())

--- a/norse/torch/module/test/test_snn.py
+++ b/norse/torch/module/test/test_snn.py
@@ -205,6 +205,7 @@ def test_snn_recurrent_record_state():
     assert y.i.shape == (3, 4)
     assert y.z.shape == (3, 4)
 
+
 def test_snn_record_nested_state():
     n = lif_refrac.LIFRefracRecurrent(
         2,
@@ -215,6 +216,7 @@ def test_snn_record_nested_state():
     assert isinstance(y, LIFRefracState)
     assert isinstance(y.lif, LIFState)
     assert y.rho.shape == (3, 4)
+
 
 def test_snn_recurrent_repr():
     n = snn.SNNRecurrent(None, None, 1, 2, MockParams())


### PR DESCRIPTION
Allows the use of a flag to record and return states for SNN modules lifted in time. Currently, this has to be done manually.

```python

l = LIF(..., record_states=True)
_, states = l(...)
```