### PR TITLE
feature: investigate norse module jitting

### DIFF
--- a/norse/torch/functional/lif.py
+++ b/norse/torch/functional/lif.py
@@ -120,13 +120,13 @@ class LIFParametersJIT(NamedTuple):
         alpha (torch.Tensor): hyper parameter to use in surrogate gradient computation
     """
 
-    tau_syn_inv: torch.Tensor
-    tau_mem_inv: torch.Tensor
-    v_leak: torch.Tensor
-    v_th: torch.Tensor
-    v_reset: torch.Tensor
-    method: str
-    alpha: torch.Tensor
+    tau_syn_inv: float =  1.0/5e-3
+    tau_mem_inv: float = 1.0/1e-2
+    v_leak: float = 0.0
+    v_th: float = 1.0
+    v_reset: float = 0.0
+    method: str = "super"
+    alpha: float = 100.0
 
 
 @torch.jit.script

--- a/norse/torch/module/test/test_script_module.py
+++ b/norse/torch/module/test/test_script_module.py
@@ -1,0 +1,67 @@
+from typing import Tuple
+import torch
+from norse.torch import LIFFeedForwardState
+from norse.torch.functional.lif import _lif_feed_forward_step_jit, LIFParametersJIT
+
+
+class LiftJ(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module):
+        super(LiftJ, self).__init__()
+        self.lifted_module = module
+
+    def forward(
+        self, x: torch.Tensor
+    ) -> torch.Tensor:
+
+        T = x.shape[0]
+        outputs = []
+
+        for ts in range(T):
+            out = self.lifted_module(x[ts])
+            outputs += [out]
+
+        return torch.stack(outputs)
+
+class LIFJ(torch.nn.Module):
+    def __init__(
+        self,
+        p: LIFParametersJIT = LIFParametersJIT(),
+        dt: float = 0.001
+    ):
+        super().__init__()
+        self.p = p
+        self.dt = dt
+
+    def extra_repr(self) -> str:
+        return f"p={self.p}, dt={self.dt}"
+
+    def forward(self, input_tensor: torch.Tensor):
+        T = input_tensor.shape[0]
+        outputs = []
+        state = LIFFeedForwardState(
+            v = torch.zeros(input_tensor.shape[1:], device=input_tensor.device),
+            i = torch.zeros(input_tensor.shape[1:], device=input_tensor.device)
+        )
+
+        for ts in range(T):
+            out, state = _lif_feed_forward_step_jit(
+                input_tensor[ts],
+                state,
+                LIFParametersJIT(*self.p),
+                self.dt,
+            )
+            outputs.append(out)
+
+        return torch.stack(outputs) #, state
+
+def test_script_module():
+    model = torch.nn.Sequential(
+        LiftJ(torch.nn.Conv2d(1, 20, 5, 1)),
+        LIFJ(),
+        LiftJ(torch.nn.Conv2d(20, 50, 5, 1)),
+        LIFJ(),
+        LiftJ(torch.nn.Flatten()),
+        LiftJ(torch.nn.Linear(800, 10))
+    )
+
+    torch.jit.script(model)


### PR DESCRIPTION
This is the beginning of a longer set of features that we should tackle both to improve performance and make integration with hardware backends easier. TorchScript has certain restrictions for which kinds of constructs it allows and ideally all core norse modules should be compatible with it. This could mean that some of the more "convenient" features we have implemented might need to be rethought.

The first commit just tests out the minimal set of modifications necessary to make jitting a sequence of norse modules work using the example of the LIF neuron model.