### PR TITLE
Fix Cifar10 example

### DIFF
--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -155,6 +155,7 @@ def main(args):
     # Load datasets
     transform_train = torchvision.transforms.Compose(
         [
+            torchvision.transforms.ToTensor(),
             torchvision.transforms.RandomCrop(32, padding=4),
             torchvision.transforms.RandomHorizontalFlip(),
         ]


### PR DESCRIPTION
Running the existing example of Cifar-10 fails with the following error:

`
File "/home/hammouda/.local/lib/python3.6/site-packages/norse/task/cifar10.py", line 186, in main 
trainer.fit(model, train_loader, val_loader)`

`TypeError: default_collate: batch must contain tensors, numpy arrays, numbers, dicts or lists; found <class 'PIL.Image.Image'>
`

Adding the missing transformation from image to tensor fixes it.