### PR TITLE
Typo fix

### DIFF
--- a/docs/pages/spiking.ipynb
+++ b/docs/pages/spiking.ipynb
@@ -235,7 +235,7 @@
    "source": [
     "## Our first Spiking Neuron\n",
     "\n",
-    "Spikes that stimulate a neuron in close succession lead to an increasingly higher membrane potential, which is in some sense the foundational principle of information processing with spiking neurons: If one replaces the Leaky Integrator with a Leaky Integrate and *Fire* neuron model (```LIF```) one arrives at the simplest *spiking* neuron model implemented in norse. Since we only return the spike train produced by a ```LIF``` neuron by default we define a simple helper function first, which also records the voltage trace. To do so we use the ```LIFCell``` module, which only computes the state evolution for one timestep. "
+    "Spikes that stimulate a neuron in close succession lead to an increasingly higher membrane potential, which is in some sense the foundational principle of information processing with spiking neurons: If one replaces the Leaky Integrator with a Leaky Integrate and *Fire* neuron model (```LIF```) one arrives at the simplest *spiking* neuron model implemented in Norse. Since we only return the spike train produced by a ```LIF``` neuron by default we define a simple helper function first, which also records the voltage trace. To do so we use the ```LIFCell``` module, which only computes the state evolution for one timestep. "
    ]
   },
   {

--- a/docs/pages/working.ipynb
+++ b/docs/pages/working.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "(page-working)=\n",
     "\n",
@@ -25,11 +26,11 @@
     ":::{note}\n",
     "You can execute the code below by hitting <i class=\"fas fa-rocket\"></i> above and pressing <i class=\"fas fa-play\"></i> Live Code.\n",
     ":::"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Terminology\n",
     "\n",
@@ -57,12 +58,13 @@
     "spikes. In Norse, we refer to that as the **neuron state**.\n",
     "\n",
     "In code, it looks like this:\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import torch\n",
     "import norse.torch as norse\n",
@@ -72,12 +74,11 @@
     "spikes, state = cell(data)        # First run is done without any state\n",
     "# ...\n",
     "spikes, state = cell(data, state) # Now we pass in the previous state"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     ":::{figure-md} started-lif\n",
     "<img src=\"../images/lif_integration.gif\" alt=\"no-current\" class=\"bg-primary mb-1\" >\n",
@@ -85,21 +86,21 @@
     "Three examples of how the LIF neuron model responds to three different, but constant, input currents: 0.0, 0.1, and 0.3. At 0.3, we see that the neuron fires a series of spikes, followed by a membrane \"reset\".\n",
     "Note that the neuron parameters are non-biological and that the memebrane voltage threshold is 1.\n",
     ":::\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "States typically consist of two values: `v` (voltage), and `i` (current).\n",
     "\n",
-    "* Voltage (`v`) illustrates the difference in \"electic tension\" in the neuron membrane. The higher the value, the more tension and better chance to arrive at a spike. In {numref}`fig_working_ap` the spike arrives at the peak of the curve, followed by an immediate reset and recovery. This is crucial for emitting spikes: if the voltage never increases - no spike!\n",
+    "* Voltage (`v`) illustrates the difference in \"electric tension\" in the neuron membrane. The higher the value, the more tension and better chance to arrive at a spike. In {numref}`fig_working_ap` the spike arrives at the peak of the curve, followed by an immediate reset and recovery. This is crucial for emitting spikes: if the voltage never increases - no spike!\n",
     "* Current (`i`) illustrates the incoming current, which will be integrated into the membrane potential `v` and decays over time.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Neuron dynamics and time\n",
     "\n",
@@ -116,11 +117,11 @@
     "\n",
     "In other words, the `LSNNCell` is *not* recurrent, and expects the input data to *not* have time, while the\n",
     "`LSNNRecurrent` *is* recurrent and expects the input to have time in the *first* dimension."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Norse workflow\n",
     "\n",
@@ -137,11 +138,11 @@
     "\n",
     "1. Neuron models \n",
     "2. Learning algorithms and/or plasticity models \n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "\n",
     "### Deciding on neuron models\n",
@@ -155,11 +156,11 @@
     "Optimization can be done using PyTorch's gradient-based optimizations, as seen in the [MNIST task](https://github.com/norse/norse/blob/master/norse/task/mnist.py#L100). We have implemented [SuperSpike](https://arxiv.org/abs/1705.11146v2) and many other [surrogate gradient methods](https://arxiv.org/abs/1901.09948) that lets you seamlessly integrate with Norse. The surrogate gradient methods are documented here: https://norse.github.io/norse/norse.torch.functional.html#threshold-functions\n",
     "\n",
     "If you require biological/local learning, we support plasticity via [STDP](https://norse.github.io/norse/generated/norse.torch.functional.stdp.html#module-norse.torch.functional.stdp) and [Tsodyks-Markram](https://norse.github.io/norse/generated/norse.torch.functional.tsodyks_makram.html#module-norse.torch.functional.tsodyks_makram) models."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Examples of deep learning problems in Norse\n",
     "\n",
@@ -170,8 +171,7 @@
     "We have several examples of that in our [tasks section](https://norse.github.io/norse/pages/tasks.html), and [MNIST](https://github.com/norse/norse/blob/master/norse/task/mnist.py) is one of them; here we 1) build a convolutional network, 2) convert the MNIST dataset into sparse discrete events and 3) solve the task with LIF models, achieving >90% accuracy.\n",
     "\n",
     "We can also **replicate experiments from the literature**, as shown in the [memory task](https://github.com/norse/norse/blob/master/norse/task/memory.py) example. Here we use [adaptive long short-term spiking neural networks](https://github.com/IGITUGraz/LSNN-official) to solve temporal memory problems."
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -179,20 +179,20 @@
    "hash": "1d7c6e90a74384adccd95650de7b60ccf01b88e91c61eab2330936fc6c29e88b"
   },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.10 64-bit ('norse': venv)"
+   "display_name": "Python 3.8.10 64-bit ('norse': venv)",
+   "name": "python3"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.8.10",
-   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "pygments_lexer": "ipython3",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
    "nbconvert_exporter": "python",
-   "file_extension": ".py"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Fixed two very small typos in the following files

docs/pages/working.ipynb
 "electic" to "eletcric" (line 96)

docs/pages/spiking.ipynb
 "norse" to "Norse" (line 238)