### PR TITLE
Fix[ci] spack (concretization of py-torch)

### DIFF
--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -24,7 +24,7 @@ cp "$WORKSPACE/spack/package.py" custom_repo/packages/py-norse
 spack repo add "${TMP_DIR}/custom_repo"
 
 # we install a stripped down py-torch (no cuda, mpi, ...)
-PACKAGE_PYTORCH="py-torch~cuda~cudnn~mkldnn~distributed~nccl"
+PACKAGE_PYTORCH="py-torch~cuda~mkldnn~distributed~nccl"
 
 # the ubuntu CI runner runs on multiple cpu archs; compile for an old one
 ARCH="linux-ubuntu20.04-sandybridge"

--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -24,7 +24,7 @@ cp "$WORKSPACE/spack/package.py" custom_repo/packages/py-norse
 spack repo add "${TMP_DIR}/custom_repo"
 
 # we install a stripped down py-torch (no cuda, mpi, ...)
-PACKAGE_PYTORCH="py-torch~cuda~mkldnn~distributed~nccl"
+PACKAGE_PYTORCH="py-torch@:1.10~cuda~mkldnn~rocm~distributed~onnx_ml~xnnpack~valgrind"
 
 # the ubuntu CI runner runs on multiple cpu archs; compile for an old one
 ARCH="linux-ubuntu20.04-x86_64"

--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -27,7 +27,7 @@ spack repo add "${TMP_DIR}/custom_repo"
 PACKAGE_PYTORCH="py-torch~cuda~mkldnn~distributed~nccl"
 
 # the ubuntu CI runner runs on multiple cpu archs; compile for an old one
-ARCH="linux-ubuntu20.04-sandybridge"
+ARCH="linux-ubuntu20.04-x86_64"
 
 spack spec -I py-norse@master ^${PACKAGE_PYTORCH} arch=${ARCH}
 


### PR DESCRIPTION
Variant `cudnn` isn't available without variant `cuda` being active…