### PR TITLE
Add[ci/spack] nightly job

### DIFF
--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -45,10 +45,19 @@ spack spec -I py-norse@master ^${PACKAGE_PYTORCH} arch=${ARCH}
 
 # enable buildcache (for faster CI)
 spack mirror add spack_ci_cache "${BUILDCACHE_MIRROR}"
+
+# drop py-norse CI builds from build cache
+rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*/*/py-norse-master
+rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*-py-norse-master-*.json
+
+# (re)index the cache
 spack buildcache update-index -d "${BUILDCACHE_MIRROR}"
 
 echo "Build cache contents:"
-spack buildcache list
+spack buildcache list -aL
+
+echo "Installed spack packages (pre-build):"
+spack find -L
 
 # drop staged builds anyways
 spack clean --stage
@@ -60,8 +69,8 @@ fi
 ret=0
 spack dev-build --source-path "${WORKSPACE}" py-norse@master ^${PACKAGE_PYTORCH} arch=${ARCH} || ret=$?
 
-echo "Installed spack packages:"
-spack find --no-groups -L
+echo "Installed spack packages (post-build):"
+spack find -L
 
 # fill build cache
 mkdir -p "${BUILDCACHE_MIRROR}"

--- a/.github/workflows/spack_build_nightly.yml
+++ b/.github/workflows/spack_build_nightly.yml
@@ -1,7 +1,8 @@
-name: Build via Spack
+name: Build via Spack (nightly)
 
 on:
-  pull_request:
+  schedule:
+    - cron: '4 2 * * *'
 
 jobs:
   build:
@@ -16,7 +17,6 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.spack-cache
-          key: cache-spack-${{ github.ref }}
-          restore-keys: cache-spack-main-latest
+          key: cache-spack-main-latest
       - name: Build norse's Spack package
         run: .github/spack/build_spack_package.sh


### PR DESCRIPTION
In #335, we fixed spack's "PR-internal" caching behavior.
This PR introduces a nightly job that can serve as base cache for all future PRs (via `restore-keys`).