### PR TITLE
Cleanup[ci/spack]

### DIFF
--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -25,7 +25,7 @@ cp "$WORKSPACE/spack/package.py" custom_repo/packages/py-norse
 spack repo add "${TMP_DIR}/custom_repo"
 
 # we install a stripped down py-torch (no cuda, mpi, ...)
-PACKAGE_PYTORCH="py-torch@:1.10~cuda~mkldnn~rocm~distributed~onnx_ml~xnnpack~valgrind"
+PACKAGE_PYTORCH="py-torch~cuda~mkldnn~rocm~distributed~onnx_ml~xnnpack~valgrind"
 
 # the ubuntu CI runner runs on multiple cpu archs; compile for an old one
 ARCH="linux-ubuntu20.04-x86_64"

--- a/.github/spack/build_spack_package.sh
+++ b/.github/spack/build_spack_package.sh
@@ -39,16 +39,16 @@ spack compilers
 
 echo "spack spec of increasing specificity:"
 spack spec ${PACKAGE_PYTORCH}
-spack spec py-norse@master
-spack spec py-norse@master ^${PACKAGE_PYTORCH}
-spack spec -I py-norse@master ^${PACKAGE_PYTORCH} arch=${ARCH}
+spack spec py-norse@main
+spack spec py-norse@main ^${PACKAGE_PYTORCH}
+spack spec -I py-norse@main ^${PACKAGE_PYTORCH} arch=${ARCH}
 
 # enable buildcache (for faster CI)
 spack mirror add spack_ci_cache "${BUILDCACHE_MIRROR}"
 
 # drop py-norse CI builds from build cache
-rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*/*/py-norse-master
-rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*-py-norse-master-*.json
+rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*/*/py-norse-main
+rm -rf "${BUILDCACHE_MIRROR}"/build_cache/*-py-norse-main-*.json
 
 # (re)index the cache
 spack buildcache update-index -d "${BUILDCACHE_MIRROR}"
@@ -67,7 +67,7 @@ if spack find py-norse; then
 fi
 
 ret=0
-spack dev-build --source-path "${WORKSPACE}" py-norse@master ^${PACKAGE_PYTORCH} arch=${ARCH} || ret=$?
+spack dev-build --source-path "${WORKSPACE}" py-norse@main ^${PACKAGE_PYTORCH} arch=${ARCH} || ret=$?
 
 echo "Installed spack packages (post-build):"
 spack find -L

--- a/spack/package.py
+++ b/spack/package.py
@@ -13,7 +13,7 @@ class PyNorse(PythonPackage):
     git = "https://github.com/norse/norse.git"
     pypi = "norse/norse-0.0.7.post1.tar.gz"
 
-    version("master", branch="master")
+    version("main", branch="main")
     version(
         "0.0.7.post1",
         sha256="aeea3bd08f47fcfe3b301f1190928dec482938956a1ab8ba568851deed94bda5",

--- a/spack/package.py
+++ b/spack/package.py
@@ -26,6 +26,9 @@ class PyNorse(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-pybind11", type=("build", "link", "run"))
 
+    # ninja preferred when building a py-torch extension (from py-torch package)
+    depends_on('ninja@1.5:', when='^py-torch@1.1:', type='build')
+
     def setup_build_environment(self, env):
         include = []
         library = []


### PR DESCRIPTION
* the repo switched from `master` to `main` quite some time ago → follow up for spack
* use ninja for py-torch extension build (fixes a warning about this)
* unpins py-torch