### PR TITLE
Added pytree state and support for torch.compile

### DIFF
--- a/.github/workflows/benchmark_norse.yml
+++ b/.github/workflows/benchmark_norse.yml
@@ -12,7 +12,7 @@ jobs:
     # Only run on self-hosted Hugin machine
     runs-on: self-hosted
     container: 
-      image: python:3.10
+      image: python:3.11
       options: --gpus 1
     steps:
       - name: Checkout

--- a/.github/workflows/documentation_build.yml
+++ b/.github/workflows/documentation_build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install system dependencies
         run: sudo apt update && sudo apt install g++ -y
       - name: Fix sphinx-jupyterbook-latex bug

--- a/.github/workflows/documentation_publish.yml
+++ b/.github/workflows/documentation_publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install system dependencies
         run: sudo apt update && sudo apt install g++ -y
       - name: Fix sphinx-jupyterbook-latex bug

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt update
           sudo apt install g++ -y
       - name: Install test dependencies
-        run: pip install pytest-cov pytest-xdist pytype black
+        run: pip install pytest-cov pytest-xdist pytype black onnx
       - name: Install optional libraries
         run: pip install matplotlib tensorboard pytorch-lightning spack
       - name: Install package
@@ -83,7 +83,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install build dependencies
         run: |
-          pip install setuptools wheel pytest-xdist tensorboard
+          pip install setuptools wheel pytest-xdist tensorboard onnx
           pip install -e .
       - name: Run unit tests
         run: pytest -n auto norse

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -18,11 +18,11 @@ jobs:
   #         pre-build-command: 'source publish/setup_libtorch.sh 1.9.1'
 
   build-python-ubuntu:
-    name: "Build and analyze for ubuntu-latest: Python v3.9"
+    name: "Build and analyze for ubuntu-latest: Python v3.10"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: '3.10'
     steps:
       - uses: actions/checkout@master
       - name: Cache
@@ -73,12 +73,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install build dependencies

--- a/.github/workflows/python_publish_pypi.yml
+++ b/.github/workflows/python_publish_pypi.yml
@@ -31,11 +31,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install build dependencies

--- a/.github/workflows/spack_build.yml
+++ b/.github/workflows/spack_build.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.11]
         compiler-version: [gcc@11.3.0]
-        spack-python: ['python@3.7', 'python@3.10']
+        spack-python: ['python@3.8', 'python@3.10']
         spack-pytorch: ['py-torch@1.9', 'py-torch@1.11']
         exclude:
           # dep. py-torchvision for py-torch@1.9 is limited to python@3.6:3.9

--- a/.github/workflows/spack_build_nightly.yml
+++ b/.github/workflows/spack_build_nightly.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.10]
         compiler-version: [gcc@11.3.0]
-        spack-python: ['python@3.7', 'python@3.10']
+        spack-python: ['python@3.8', 'python@3.10']
         spack-pytorch: ['py-torch@1.9', 'py-torch@1.11']
         exclude:
           # dep. py-torchvision for py-torch@1.9 is limited to python@3.6:3.9

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here, we describe how to install Norse and start to apply it in your own work.
 ### 2.1. Installation
 <a name="installation"></a>
 
-We assume you are using **Python version 3.7+** and have **installed PyTorch version 1.9 or higher**. 
+We assume you are using **Python version 3.8+** and have **installed PyTorch version 1.9 or higher**. 
 [Read more about the prerequisites in our documentation](https://norse.github.io/norse/installing.html).
 
 <table>

--- a/docs/pages/installing.md
+++ b/docs/pages/installing.md
@@ -14,7 +14,7 @@ This has the benefit that your models are hardware accelerated, providing the [p
 To install Norse, you need the following two dependencies:
 1. `pip` - the [Python package manager](https://pypi.org/project/pip/)
    * This is preinstalled in most Linux and Unix distros
-   * Note that Norse requires Python >= 3.7
+   * Note that Norse requires Python >= 3.8
 2. `torch` - the [deep learning accelerator](https://pytorch.org/get-started/locally/)
    * Please follow the guide available here https://pytorch.org/get-started/locally/
    * Select the CUDA version if you require GPU hardware acceleration

--- a/norse/benchmark/norse_lif.py
+++ b/norse/benchmark/norse_lif.py
@@ -4,7 +4,7 @@ import torch
 from norse.torch.functional.lif import (
     LIFFeedForwardState,
     LIFParameters,
-    _lif_feed_forward_integral_jit,
+    lif_feed_forward_integral,
 )
 from norse.torch.module.encode import PoissonEncoder
 
@@ -24,7 +24,7 @@ class LIFBenchmark(torch.jit.ScriptModule):
         self, input_spikes: torch.Tensor, p: LIFParameters, s: LIFFeedForwardState
     ):
         x = self.fc(input_spikes)
-        return _lif_feed_forward_integral_jit(input_tensor=x, state=s, p=p, dt=self.dt)
+        return lif_feed_forward_integral(input_tensor=x, state=s, p=p, dt=self.dt)
 
 
 def lif_feed_forward_benchmark(parameters: BenchmarkParameters):

--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -8,6 +8,7 @@ import torch.utils.data
 
 # pytype: disable=import-error
 import pytorch_lightning as pl
+
 # pytype: enable=import-error
 
 from norse.torch.module import LIFCell, SequentialState, LICell

--- a/norse/task/cifar10.py
+++ b/norse/task/cifar10.py
@@ -5,7 +5,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.data
+
+# pytype: disable=import-error
 import pytorch_lightning as pl
+# pytype: enable=import-error
 
 from norse.torch.module import LIFCell, SequentialState, LICell
 from norse.torch.functional.lif import LIFParameters

--- a/norse/task/memory.py
+++ b/norse/task/memory.py
@@ -5,9 +5,12 @@ import matplotlib
 import matplotlib.colors as colors
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
-import pytorch_lightning as pl
 import torch
 import torch.utils.data
+
+# pytype: disable=import-error
+import pytorch_lightning as pl
+# pytype: enable=import-error
 
 from norse.dataset.memory import MemoryStoreRecallDataset
 from norse.torch.module.leaky_integrator import LILinearCell

--- a/norse/task/memory.py
+++ b/norse/task/memory.py
@@ -10,6 +10,7 @@ import torch.utils.data
 
 # pytype: disable=import-error
 import pytorch_lightning as pl
+
 # pytype: enable=import-error
 
 from norse.dataset.memory import MemoryStoreRecallDataset

--- a/norse/task/mnist_pl.py
+++ b/norse/task/mnist_pl.py
@@ -11,7 +11,9 @@ import torch
 import torch.utils.data
 import torchvision
 
+# pytype: disable=import-error
 import pytorch_lightning as pl
+# pytype: enable=import-error
 
 import norse.torch as norse
 

--- a/norse/task/mnist_pl.py
+++ b/norse/task/mnist_pl.py
@@ -13,6 +13,7 @@ import torchvision
 
 # pytype: disable=import-error
 import pytorch_lightning as pl
+
 # pytype: enable=import-error
 
 import norse.torch as norse

--- a/norse/torch/functional/lif.py
+++ b/norse/torch/functional/lif.py
@@ -27,7 +27,7 @@ gradient approach that uses the :mod:`.heaviside` step function:
     H[n]=\begin{cases} 0, & n <= 0 \\ 1, & n \gt 0 \end{cases}
 
 """
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Tuple
 import torch
 import torch.jit
 
@@ -37,7 +37,6 @@ except ModuleNotFoundError:  # pragma: no cover
     pass
 
 from norse.torch.functional.threshold import threshold
-from norse.torch.utils.pytree import StateTuple, MultipleInheritanceNamedTupleMeta
 
 
 class LIFParameters(NamedTuple):

--- a/norse/torch/functional/lif.py
+++ b/norse/torch/functional/lif.py
@@ -37,6 +37,7 @@ except ModuleNotFoundError:  # pragma: no cover
     pass
 
 from norse.torch.functional.threshold import threshold
+from norse.torch.utils.pytree import StateTuple, MultipleInheritanceNamedTupleMeta
 
 
 class LIFParameters(NamedTuple):
@@ -104,68 +105,12 @@ class LIFFeedForwardState(NamedTuple):
     i: torch.Tensor
 
 
-class LIFParametersJIT(NamedTuple):
-    """Parametrization of a LIF neuron
-
-    Parameters:
-        tau_syn_inv (torch.Tensor): inverse synaptic time
-                                    constant (:math:`1/\\tau_\\text{syn}`) in 1/ms
-        tau_mem_inv (torch.Tensor): inverse membrane time
-                                    constant (:math:`1/\\tau_\\text{mem}`) in 1/ms
-        v_leak (torch.Tensor): leak potential in mV
-        v_th (torch.Tensor): threshold potential in mV
-        v_reset (torch.Tensor): reset potential in mV
-        method (str): method to determine the spike threshold
-                      (relevant for surrogate gradients)
-        alpha (torch.Tensor): hyper parameter to use in surrogate gradient computation
-    """
-
-    tau_syn_inv: torch.Tensor
-    tau_mem_inv: torch.Tensor
-    v_leak: torch.Tensor
-    v_th: torch.Tensor
-    v_reset: torch.Tensor
-    method: str
-    alpha: torch.Tensor
-
-
-@torch.jit.script
-def _lif_step_jit(
-    input_spikes: torch.Tensor,
-    state: LIFState,
-    input_weights: torch.Tensor,
-    recurrent_weights: torch.Tensor,
-    p: LIFParametersJIT,
-    dt: float = 0.001,
-) -> Tuple[torch.Tensor, LIFState]:  # pragma: no cover
-    # compute current jumps
-    i_jump = (
-        state.i
-        + torch.nn.functional.linear(input_spikes, input_weights)
-        + torch.nn.functional.linear(state.z, recurrent_weights)
-    )
-    # compute voltage updates
-    dv = dt * p.tau_mem_inv * ((p.v_leak - state.v) + i_jump)
-    v_decayed = state.v + dv
-
-    # compute current updates
-    di = -dt * p.tau_syn_inv * i_jump
-    i_decayed = i_jump + di
-
-    # compute new spikes
-    z_new = threshold(v_decayed - p.v_th, p.method, p.alpha)
-    # compute reset
-    v_new = (1 - z_new.detach()) * v_decayed + z_new.detach() * p.v_reset
-
-    return z_new, LIFState(z_new, v_new, i_decayed)
-
-
 def lif_step_sparse(
     input_spikes: torch.Tensor,
     state: LIFState,
     input_weights: torch.Tensor,
     recurrent_weights: torch.Tensor,
-    p: LIFParameters = LIFParameters(),
+    p: LIFParameters,
     dt: float = 0.001,
 ) -> Tuple[torch.Tensor, LIFState]:
     r"""Computes a single euler-integration step of a LIF neuron-model. More
@@ -231,7 +176,7 @@ def lif_step(
     state: LIFState,
     input_weights: torch.Tensor,
     recurrent_weights: torch.Tensor,
-    p: LIFParameters = LIFParameters(),
+    p: LIFParameters,
     dt: float = 0.001,
 ) -> Tuple[torch.Tensor, LIFState]:
     r"""Computes a single euler-integration step of a LIF neuron-model. More
@@ -268,9 +213,26 @@ def lif_step(
         p (LIFParameters): parameters of a leaky integrate and fire neuron
         dt (float): Integration timestep to use
     """
-    return _lif_step_jit(
-        input_spikes, state, input_weights, recurrent_weights, LIFParametersJIT(*p), dt
+    # compute current jumps
+    i_jump = (
+        state.i
+        + torch.nn.functional.linear(input_spikes, input_weights)
+        + torch.nn.functional.linear(state.z, recurrent_weights)
     )
+    # compute voltage updates
+    dv = dt * p.tau_mem_inv * ((p.v_leak - state.v) + i_jump)
+    v_decayed = state.v + dv
+
+    # compute current updates
+    di = -dt * p.tau_syn_inv * i_jump
+    i_decayed = i_jump + di
+
+    # compute new spikes
+    z_new = threshold(v_decayed - p.v_th, p.method, p.alpha)
+    # compute reset
+    v_new = (1 - z_new.detach()) * v_decayed + z_new.detach() * p.v_reset
+
+    return z_new, LIFState(z_new, v_new, i_decayed)
 
 
 def lif_step_integral(
@@ -324,35 +286,10 @@ def lif_step_integral(
     return z, LIFState(z=z, v=v, i=i)
 
 
-@torch.jit.script
-def _lif_feed_forward_step_jit(
-    input_tensor: torch.Tensor,
-    state: LIFFeedForwardState,
-    p: LIFParametersJIT,
-    dt: float = 0.001,
-) -> Tuple[torch.Tensor, LIFFeedForwardState]:  # pragma: no cover
-    # compute voltage updates
-    dv = dt * p.tau_mem_inv * ((p.v_leak - state.v) + state.i)
-    v_decayed = state.v + dv
-
-    # compute current updates
-    di = -dt * p.tau_syn_inv * state.i
-    i_decayed = state.i + di
-
-    # compute new spikes
-    z_new = threshold(v_decayed - p.v_th, p.method, p.alpha)
-    # compute reset
-    v_new = (1 - z_new) * v_decayed + z_new * p.v_reset
-    # compute current jumps
-    i_new = i_decayed + input_tensor
-
-    return z_new, LIFFeedForwardState(v=v_new, i=i_new)
-
-
 def lif_feed_forward_step(
     input_spikes: torch.Tensor,
     state: LIFFeedForwardState,
-    p: LIFParameters = LIFParameters(),
+    p: LIFParameters,
     dt: float = 0.001,
 ) -> Tuple[torch.Tensor, LIFFeedForwardState]:
     r"""Computes a single euler-integration step for a lif neuron-model.
@@ -388,14 +325,28 @@ def lif_feed_forward_step(
         p (LIFParameters): parameters of a leaky integrate and fire neuron
         dt (float): Integration timestep to use
     """
-    z, state = _lif_feed_forward_step_jit(input_spikes, state, LIFParametersJIT(*p), dt)
-    return z, state
+    # compute voltage updates
+    dv = dt * p.tau_mem_inv * ((p.v_leak - state.v) + state.i)
+    v_decayed = state.v + dv
+
+    # compute current updates
+    di = -dt * p.tau_syn_inv * state.i
+    i_decayed = state.i + di
+
+    # compute new spikes
+    z_new = threshold(v_decayed - p.v_th, p.method, p.alpha)
+    # compute reset
+    v_new = (1 - z_new) * v_decayed + z_new * p.v_reset
+    # compute current jumps
+    i_new = i_decayed + input_spikes
+
+    return z_new, LIFFeedForwardState(v=v_new, i=i_new)
 
 
 def lif_feed_forward_integral(
     input_tensor: torch.Tensor,
     state: LIFFeedForwardState,
-    p: LIFParameters = LIFParameters(),
+    p: LIFParameters,
     dt: float = 0.001,
 ) -> Tuple[torch.Tensor, LIFFeedForwardState]:
     r"""Computes multiple euler-integration steps of a LIF neuron-model. More
@@ -449,63 +400,6 @@ def lif_feed_forward_integral(
     return torch.stack(outputs), state
 
 
-@torch.jit.script
-def _lif_feed_forward_integral_jit(
-    input_tensor: torch.Tensor,
-    state: LIFFeedForwardState,
-    p: LIFParametersJIT,
-    dt: float = 0.001,
-) -> Tuple[torch.Tensor, LIFFeedForwardState]:
-    r"""Computes multiple euler-integration steps of a LIF neuron-model. More
-    specifically it integrates the following ODE
-
-    .. math::
-        \begin{align*}
-            \dot{v} &= 1/\tau_{\text{mem}} (v_{\text{leak}} - v + i) \\
-            \dot{i} &= -1/\tau_{\text{syn}} i
-        \end{align*}
-
-    together with the jump condition
-
-    .. math::
-        z = \Theta(v - v_{\text{th}})
-
-    and transition equations
-
-    .. math::
-        \begin{align*}
-            v &= (1-z) v + z v_{\text{reset}} \\
-            i &= i + i_{\text{in}}
-        \end{align*}
-
-    Parameters:
-        input_tensor (torch.Tensor): the input spikes with the outer dimension assumed to be timesteps
-        s (LIFState): current state of the LIF neuron
-        p (LIFParameters): parameters of a leaky integrate and fire neuron
-        dt (float): Integration timestep to use
-    """
-    outputs = []
-    for input_spikes in input_tensor:
-        # compute voltage updates
-        dv = dt * p.tau_mem_inv * ((p.v_leak - state.v) + state.i)
-        v_decayed = state.v + dv
-
-        # compute current updates
-        di = -dt * p.tau_syn_inv * state.i
-        i_decayed = state.i + di
-
-        # compute new spikes
-        z_new = threshold(v_decayed - p.v_th, p.method, p.alpha)
-        # compute reset
-        v_new = (1 - z_new) * v_decayed + z_new * p.v_reset
-        # compute current jumps
-        i_new = i_decayed + input_spikes
-
-        outputs.append(z_new)
-        state = LIFFeedForwardState(v=v_new, i=i_new)
-    return torch.stack(outputs), state
-
-
 def lif_feed_forward_step_sparse(
     input_tensor: torch.Tensor,
     state: LIFFeedForwardState,
@@ -534,7 +428,7 @@ def lif_feed_forward_step_sparse(
 def lif_current_encoder(
     input_current: torch.Tensor,
     voltage: torch.Tensor,
-    p: LIFParameters = LIFParameters(),
+    p: LIFParameters,
     dt: float = 0.001,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Computes a single euler-integration step of a leaky integrator. More

--- a/norse/torch/functional/test/test_izhikevich.py
+++ b/norse/torch/functional/test/test_izhikevich.py
@@ -23,7 +23,6 @@ def test_tonic_spiking():
             input_current = 0 * torch.ones(1)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
         cs.append(input_current)
-    return vs, cs
 
 
 def test_phasic_spiking():
@@ -43,7 +42,6 @@ def test_phasic_spiking():
             input_current = 0 * torch.ones(1)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
         cs.append(input_current)
-    return vs, cs
 
 
 def test_tonic_bursting():
@@ -64,7 +62,6 @@ def test_tonic_bursting():
         _, s = izhikevich_feed_forward_step(input_current, s, p)
 
         cs.append(input_current)
-    return vs, cs
 
 
 def test_phasic_bursting():
@@ -83,7 +80,6 @@ def test_phasic_bursting():
             input_current = 0 * torch.ones(1)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
         cs.append(input_current)
-    return vs, cs
 
 
 def test_mixed_mode():
@@ -103,7 +99,6 @@ def test_mixed_mode():
             input_current = 0 * torch.ones(1)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
         cs.append(input_current)
-    return vs, cs
 
 
 def test_spike_frequency_adaptation():
@@ -124,7 +119,6 @@ def test_spike_frequency_adaptation():
         _, s = izhikevich_feed_forward_step(input_current, s, p)
 
         cs.append(input_current)
-    return vs, cs
 
 
 def test_class_1_exc():
@@ -145,7 +139,6 @@ def test_class_1_exc():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs
 
 
 def test_class_2_exc():
@@ -166,7 +159,6 @@ def test_class_2_exc():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs
 
 
 def test_spike_latency():
@@ -187,7 +179,6 @@ def test_spike_latency():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_subthreshold_oscillation():
@@ -208,7 +199,6 @@ def test_subthreshold_oscillation():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_resonator():
@@ -238,7 +228,6 @@ def test_resonator():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_integrator():
@@ -268,7 +257,6 @@ def test_integrator():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_rebound_spike():
@@ -290,7 +278,6 @@ def test_rebound_spike():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_rebound_burst():
@@ -312,7 +299,6 @@ def test_rebound_burst():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_threshhold_variability():
@@ -337,7 +323,6 @@ def test_threshhold_variability():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_bistability():
@@ -360,7 +345,6 @@ def test_bistability():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_dap():
@@ -382,7 +366,6 @@ def test_dap():
 
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_inhibition_induced_spiking():
@@ -401,7 +384,6 @@ def test_inhibition_induced_spiking():
             input_current = 75.0 * torch.ones(1)
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_inhibition_induced_bursting():
@@ -421,7 +403,6 @@ def test_inhibition_induced_bursting():
             input_current = 75.0 * torch.ones(1)
         cs.append(input_current)
         _, s = izhikevich_feed_forward_step(input_current, s, p)
-    return vs, cs
 
 
 def test_creation():

--- a/norse/torch/functional/test/test_lif.py
+++ b/norse/torch/functional/test/test_lif.py
@@ -1,6 +1,6 @@
+import pytest, os
 import torch
 
-import norse
 from norse.torch.functional.lif import (
     LIFState,
     LIFFeedForwardState,
@@ -56,6 +56,7 @@ def test_lif_feed_forward_step_batch():
     assert z.shape == (2, 1)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_lif_feed_forward_step_compile():
     x = torch.ones(10)
     s = LIFFeedForwardState(v=torch.zeros(10), i=torch.zeros(10))
@@ -115,6 +116,7 @@ def test_lif_integral():
     assert torch.allclose(s.v, torch.tensor([0.7717]), atol=1e-4)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_lif_integral_compile():
     x = torch.ones(8, 1)
     s = LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1))

--- a/norse/torch/functional/test/test_lif.py
+++ b/norse/torch/functional/test/test_lif.py
@@ -5,14 +5,10 @@ from norse.torch.functional.lif import (
     LIFState,
     LIFFeedForwardState,
     LIFParameters,
-    LIFParametersJIT,
-    _lif_step_jit,
     lif_step,
     lif_step_integral,
     lif_feed_forward_step,
     lif_feed_forward_integral,
-    _lif_feed_forward_step_jit,
-    _lif_feed_forward_integral_jit,
     lif_current_encoder,
 )
 
@@ -23,30 +19,8 @@ def test_lif_cpp_back():
     s.v.requires_grad = True
     input_weights = torch.ones(2)
     recurrent_weights = torch.ones(1)
-    _, s = lif_step(x, s, input_weights, recurrent_weights)
-    z, s = lif_step(x, s, input_weights, recurrent_weights)
-    z.sum().backward()
-
-
-def test_lif_jit_back():
-    x = torch.ones(2, requires_grad=True)
-    s = LIFState(z=torch.zeros(1), v=torch.zeros(1), i=torch.zeros(1))
-    s.v.requires_grad = True
-    input_weights = torch.ones(2)
-    recurrent_weights = torch.ones(1)
-    p = LIFParameters()
-    jit_params = LIFParametersJIT(
-        tau_syn_inv=p.tau_syn_inv,
-        tau_mem_inv=p.tau_mem_inv,
-        v_leak=p.v_leak,
-        v_th=p.v_th,
-        v_reset=p.v_reset,
-        method=p.method,
-        alpha=torch.as_tensor(p.alpha),
-    )
-    _, s = _lif_step_jit(x, s, input_weights, recurrent_weights, p=jit_params)
-    z, s = _lif_step_jit(x, s, input_weights, recurrent_weights, p=jit_params)
-    print(x.shape, z.shape, input_weights.shape, recurrent_weights.shape)
+    _, s = lif_step(x, s, input_weights, recurrent_weights, LIFParameters())
+    z, s = lif_step(x, s, input_weights, recurrent_weights, LIFParameters())
     z.sum().backward()
 
 
@@ -55,7 +29,8 @@ def test_lif_heavi():
     s = LIFState(z=torch.ones(2, 1), v=torch.zeros(2, 1), i=torch.zeros(2, 1))
     input_weights = torch.ones(1, 1) * 10
     recurrent_weights = torch.ones(1, 1)
-    p = LIFParameters(method="heaviside")
+    p = LIFParameters()
+    p._replace(method="heaviside")
     _, s = lif_step(x, s, input_weights, recurrent_weights, p)
     z, s = lif_step(x, s, input_weights, recurrent_weights, p)
     assert z.max() > 0
@@ -69,7 +44,7 @@ def test_lif_feed_forward_step():
     results = [0.0, 0.1, 0.27, 0.487, 0.7335, 0.9963, 0.0, 0.3951, 0.7717, 0.0]
 
     for result in results:
-        _, s = lif_feed_forward_step(x, s)
+        _, s = lif_feed_forward_step(x, s, LIFParameters())
         assert torch.allclose(torch.as_tensor(result), s.v, atol=1e-4)
 
 
@@ -77,15 +52,15 @@ def test_lif_feed_forward_step_batch():
     x = torch.ones(2, 1)
     s = LIFFeedForwardState(v=torch.zeros(2, 1), i=torch.zeros(2, 1))
 
-    z, s = lif_feed_forward_step(x, s)
+    z, s = lif_feed_forward_step(x, s, LIFParameters())
     assert z.shape == (2, 1)
 
 
-def test_lif_feed_forward_step_jit():
+def test_lif_feed_forward_step_compile():
     x = torch.ones(10)
     s = LIFFeedForwardState(v=torch.zeros(10), i=torch.zeros(10))
 
-    p = LIFParametersJIT(
+    p = LIFParameters(
         torch.as_tensor(1.0 / 5e-3),
         torch.as_tensor(1.0 / 1e-2),
         torch.as_tensor(0.0),
@@ -96,9 +71,10 @@ def test_lif_feed_forward_step_jit():
     )
 
     results = [0.0, 0.1, 0.27, 0.487, 0.7335, 0.9963, 0.0, 0.3951, 0.7717, 0.0]
+    f = torch.compile(lif_feed_forward_step)
 
     for result in results:
-        _, s = _lif_feed_forward_step_jit(x, s, p)
+        _, s = f(x, s, p)
         assert torch.allclose(torch.as_tensor(result), s.v, atol=1e-4)
 
 
@@ -120,5 +96,30 @@ def test_lif_current_encoder():
     ]
 
     for result in results:
-        _, v = lif_current_encoder(x, v)
+        _, v = lif_current_encoder(x, v, LIFParameters())
         assert torch.allclose(torch.as_tensor(result), v, atol=1e-4)
+
+
+def test_lif_integral():
+    x = torch.ones(8, 1)
+    s = LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1))
+    f = lif_feed_forward_integral
+
+    z, s = f(x, s, LIFParameters())
+    assert z.sum() == 1
+    print(
+        s.v,
+        torch.tensor([0.7717]),
+        torch.allclose(s.v, torch.tensor([0.7717]), atol=1e-04),
+    )
+    assert torch.allclose(s.v, torch.tensor([0.7717]), atol=1e-4)
+
+
+def test_lif_integral_compile():
+    x = torch.ones(8, 1)
+    s = LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1))
+    f = torch.compile(lif_feed_forward_integral)
+
+    z, s = f(x, s, LIFParameters())
+    assert z.sum() == 1
+    assert torch.allclose(s.v, torch.tensor([0.7717]), atol=1e-4)

--- a/norse/torch/functional/test/test_lif.py
+++ b/norse/torch/functional/test/test_lif.py
@@ -1,4 +1,4 @@
-import pytest, os
+import pytest, platform
 import torch
 
 from norse.torch.functional.lif import (
@@ -56,7 +56,9 @@ def test_lif_feed_forward_step_batch():
     assert z.shape == (2, 1)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_lif_feed_forward_step_compile():
     x = torch.ones(10)
     s = LIFFeedForwardState(v=torch.zeros(10), i=torch.zeros(10))
@@ -116,7 +118,9 @@ def test_lif_integral():
     assert torch.allclose(s.v, torch.tensor([0.7717]), atol=1e-4)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_lif_integral_compile():
     x = torch.ones(8, 1)
     s = LIFFeedForwardState(v=torch.zeros(1), i=torch.zeros(1))

--- a/norse/torch/functional/test/test_lift.py
+++ b/norse/torch/functional/test/test_lift.py
@@ -25,6 +25,7 @@ def test_lift_with_state_without_parameters():
     z, s = lifted(
         data,
         state=LIFFeedForwardState(torch.zeros_like(data[0]), torch.zeros_like(data[0])),
+        p=LIFParameters(),
     )
     assert z.shape == (3, 2, 1)
     assert s.v.shape == (2, 1)
@@ -39,6 +40,7 @@ def test_lift_with_state_and_parameters():
     z, s = lifted(
         data,
         state=LIFFeedForwardState(torch.zeros_like(data[0]), torch.zeros_like(data[0])),
+        p=LIFParameters(),
     )
     assert z.shape == (3, 2, 1)
     assert s.v.shape == (2, 1)
@@ -57,6 +59,7 @@ def test_lift_with_lift_step():
         ),
         input_weights=torch.ones(1, 1),
         recurrent_weights=torch.ones(1, 1),
+        p=LIFParameters(),
     )
     assert z.shape == (3, 2, 1)
     assert s.v.shape == (2, 1)
@@ -72,6 +75,7 @@ def test_lift_with_leaky_integrator():
             i=torch.zeros(2, 1),
         ),
         input_weights=torch.ones(1, 1),
+        p=LIFParameters(),
     )
     assert z.shape == (3, 2, 1)
     assert s.v.shape == (2, 1)

--- a/norse/torch/functional/test/test_regularization.py
+++ b/norse/torch/functional/test/test_regularization.py
@@ -1,17 +1,21 @@
 import torch
 
-from norse.torch.functional.lif import LIFFeedForwardState, lif_feed_forward_step
+from norse.torch.functional.lif import (
+    LIFFeedForwardState,
+    LIFParameters,
+    lif_feed_forward_step,
+)
 from norse.torch.functional.regularization import regularize_step, voltage_accumulator
 
 
 def test_regularisation_spikes():
     x = torch.ones(5, 10)
     s = LIFFeedForwardState(torch.ones(10), torch.ones(10))
-    z, s = lif_feed_forward_step(x, s)
+    z, s = lif_feed_forward_step(x, s, LIFParameters())
     zr, rs = regularize_step(z, s)
     assert torch.equal(z, zr)
     assert rs == 0
-    z, s = lif_feed_forward_step(x, s)
+    z, s = lif_feed_forward_step(x, s, LIFParameters())
     zr, rs = regularize_step(z, s)
     assert rs == 50
 
@@ -19,7 +23,7 @@ def test_regularisation_spikes():
 def test_regularisation_voltage():
     x = torch.ones(5, 10)
     s = LIFFeedForwardState(torch.ones(10), torch.ones(10))
-    z, s = lif_feed_forward_step(x, s)
+    z, s = lif_feed_forward_step(x, s, LIFParameters())
     # pytype: disable=wrong-arg-types
     zr, rs = regularize_step(z, s, accumulator=voltage_accumulator)
     # pytype: enable=wrong-arg-types
@@ -31,7 +35,7 @@ def test_regularisation_voltage_state():
     x = torch.ones(5, 10)
     state = torch.zeros(10)
     s = LIFFeedForwardState(torch.ones(10), torch.ones(10))
-    z, s = lif_feed_forward_step(x, s)
+    z, s = lif_feed_forward_step(x, s, LIFParameters())
     # pytype: disable=wrong-arg-types
     zr, rs = regularize_step(z, s, accumulator=voltage_accumulator, state=state)
     # pytype: enable=wrong-arg-types

--- a/norse/torch/module/lif.py
+++ b/norse/torch/module/lif.py
@@ -22,6 +22,7 @@ from norse.torch.functional.adjoint.lif_adjoint import (
     lif_feed_forward_adjoint_step_sparse,
 )
 from norse.torch.module.snn import SNN, SNNCell, SNNRecurrent, SNNRecurrentCell
+from norse.torch.utils import clone_tensor
 
 
 class LIFCell(SNNCell):
@@ -85,12 +86,7 @@ class LIFCell(SNNCell):
 
     def initial_state(self, input_tensor: torch.Tensor) -> LIFFeedForwardState:
         state = LIFFeedForwardState(
-            v=torch.full(
-                input_tensor.shape,
-                torch.as_tensor(self.p.v_leak).detach(),
-                device=input_tensor.device,
-                dtype=torch.float32,
-            ),
+            v=clone_tensor(self.p.v_leak),
             i=torch.zeros(
                 *input_tensor.shape,
                 device=input_tensor.device,

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -1,3 +1,4 @@
+import pytest, os
 import torch
 
 from norse.torch.functional.lif import LIFState, LIFParameters
@@ -37,6 +38,7 @@ import torch._dynamo
 torch._dynamo.config.verbose = True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_lif_cell_feedforward_compile():
     layer = LIFCell()
     layer = torch.compile(layer)
@@ -57,6 +59,7 @@ def test_lif_recurrent_cell():
     assert out.shape == (5, 4)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_lif_recurrent_cell_compile():
     cell = LIFRecurrentCell(2, 4)
     cell = torch.compile(cell)
@@ -155,6 +158,7 @@ def test_lif_feedforward_layer():
         assert x.shape == (5, 4)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_lif_feedforward_layer_compile():
     layer = LIF()
     layer = torch.compile(layer)

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -32,8 +32,34 @@ def test_lif_cell_feedforward():
     assert out.shape == (5, 2)
 
 
+import torch._dynamo
+
+torch._dynamo.config.verbose = True
+
+
+def test_lif_cell_feedforward_compile():
+    layer = LIFCell()
+    layer = torch.compile(layer)
+    data = torch.randn(5, 4)
+    out, s = layer(data)
+    assert out.shape == (5, 4)
+    for x in s:
+        assert x.shape == (5, 4)
+
+
 def test_lif_recurrent_cell():
     cell = LIFRecurrentCell(2, 4)
+    data = torch.randn(5, 2)
+    out, s = cell(data)
+
+    for x in s:
+        assert x.shape == (5, 4)
+    assert out.shape == (5, 4)
+
+
+def test_lif_recurrent_cell_compile():
+    cell = LIFRecurrentCell(2, 4)
+    cell = torch.compile(cell)
     data = torch.randn(5, 2)
     out, s = cell(data)
 
@@ -122,6 +148,16 @@ def test_lif_recurrent_cell_backward():
 
 def test_lif_feedforward_layer():
     layer = LIF()
+    data = torch.randn(10, 5, 4)
+    out, s = layer(data)
+    assert out.shape == (10, 5, 4)
+    for x in s:
+        assert x.shape == (5, 4)
+
+
+def test_lif_feedforward_layer_compile():
+    layer = LIF()
+    layer = torch.compile(layer)
     data = torch.randn(10, 5, 4)
     out, s = layer(data)
     assert out.shape == (10, 5, 4)

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -33,11 +33,6 @@ def test_lif_cell_feedforward():
     assert out.shape == (5, 2)
 
 
-import torch._dynamo
-
-torch._dynamo.config.verbose = True
-
-
 @pytest.mark.skipif(
     not platform.system() == "Linux", reason="Only Linux supports torch.compile"
 )

--- a/norse/torch/module/test/test_lif.py
+++ b/norse/torch/module/test/test_lif.py
@@ -1,4 +1,4 @@
-import pytest, os
+import pytest, platform
 import torch
 
 from norse.torch.functional.lif import LIFState, LIFParameters
@@ -38,7 +38,9 @@ import torch._dynamo
 torch._dynamo.config.verbose = True
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_lif_cell_feedforward_compile():
     layer = LIFCell()
     layer = torch.compile(layer)
@@ -59,7 +61,9 @@ def test_lif_recurrent_cell():
     assert out.shape == (5, 4)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_lif_recurrent_cell_compile():
     cell = LIFRecurrentCell(2, 4)
     cell = torch.compile(cell)
@@ -158,7 +162,9 @@ def test_lif_feedforward_layer():
         assert x.shape == (5, 4)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_lif_feedforward_layer_compile():
     layer = LIF()
     layer = torch.compile(layer)

--- a/norse/torch/module/test/test_sequential.py
+++ b/norse/torch/module/test/test_sequential.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest, os
 
 import torch
 from torch import nn
@@ -13,6 +13,7 @@ def test_state_sequence():
     assert s[0].v.shape == (1, 6)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
 def test_state_sequence_compile():
     d = torch.ones(10, 1, 20)
     l = norse.LIFRecurrent(20, 6)

--- a/norse/torch/module/test/test_sequential.py
+++ b/norse/torch/module/test/test_sequential.py
@@ -1,4 +1,4 @@
-import pytest, os
+import pytest, platform
 
 import torch
 from torch import nn
@@ -13,7 +13,9 @@ def test_state_sequence():
     assert s[0].v.shape == (1, 6)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support torch.compile")
+@pytest.mark.skipif(
+    not platform.system() == "Linux", reason="Only Linux supports torch.compile"
+)
 def test_state_sequence_compile():
     d = torch.ones(10, 1, 20)
     l = norse.LIFRecurrent(20, 6)

--- a/norse/torch/module/test/test_sequential.py
+++ b/norse/torch/module/test/test_sequential.py
@@ -13,6 +13,16 @@ def test_state_sequence():
     assert s[0].v.shape == (1, 6)
 
 
+def test_state_sequence_compile():
+    d = torch.ones(10, 1, 20)
+    l = norse.LIFRecurrent(20, 6)
+    m = norse.SequentialState(l)
+    m = torch.compile(m)
+    z, s = m(d)
+    assert z.shape == (10, 1, 6)
+    assert s[0].v.shape == (1, 6)
+
+
 def test_state_sequence_apply_no_state():
     d = torch.ones(10, 1, 1)
     m = norse.SequentialState(nn.Linear(1, 1), norse.LIFCell())

--- a/norse/torch/utils/__init__.py
+++ b/norse/torch/utils/__init__.py
@@ -22,10 +22,10 @@ del logging
 
 
 def clone_tensor(x: Union[torch.Tensor, Number], device: Optional[str] = None):
-    if isinstance(x, torch.Tensor):
-        cloned = x.detach().clone()
-    elif isinstance(x, Number):
+    if isinstance(x, Number):
         cloned = torch.as_tensor(x)
+    elif isinstance(x, torch.Tensor):
+        cloned = x.detach().clone()
     else:
         raise ValueError("Expected tensor or number, but received ", x)
     if device is not None:

--- a/norse/torch/utils/__init__.py
+++ b/norse/torch/utils/__init__.py
@@ -4,6 +4,9 @@ Utilities for Norse networks in Torch.
 Packages and subpackages may depend on Matplotlib and Tensorboard.
 """
 import logging
+import torch
+from typing import Union, Optional
+from numbers import Number
 
 try:
     from .plot import *
@@ -16,3 +19,16 @@ except ImportError as e:
     logging.debug(f"Failed to import Norse plotting utilities: {e}")
 
 del logging
+
+
+def clone_tensor(x: Union[torch.Tensor, Number], device: Optional[str] = None):
+    if isinstance(x, torch.Tensor):
+        cloned = x.detach().clone()
+    elif isinstance(x, Number):
+        cloned = torch.as_tensor(x)
+    else:
+        raise ValueError("Expected tensor or number, but received ", x)
+    if device is not None:
+        return cloned.to(device)
+    else:
+        return cloned

--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -1,0 +1,126 @@
+import functools
+from numbers import Number
+import typing
+from typing import Any, Callable, Optional, Tuple, Type, TypeVar
+
+import torch
+from torch.utils._pytree import (
+    PyTree,
+    _namedtuple_flatten,
+    _namedtuple_unflatten,
+    _register_pytree_node,
+    tree_map,
+)
+
+# Thanks to https://stackoverflow.com/a/50369521
+NamedTuple = typing.NamedTuple
+if hasattr(typing.NamedTuple, "__mro_entries__"):
+    # Python 3.9 fixed and broke multiple inheritance in a different way
+    # see https://github.com/python/cpython/issues/88089
+    NamedTuple = typing._NamedTuple
+
+T = TypeVar("T")
+
+
+def map_only(ty: Type[T]) -> Callable[[Callable[[T], Any]], Callable[[Any], Any]]:
+    """
+    Returns a function that allows mapping on a certain type.
+
+    Usage:
+        mapping = map_only(some_type)
+        tree_map(mapping(fn), tree)
+    """
+
+    def callback(f: Callable[[T], Any]) -> Callable[[Any], Any]:
+        @functools.wraps(f)
+        def inner(x: T) -> Any:
+            return f(x) if isinstance(x, ty) else x
+
+        return inner
+
+    return callback
+
+
+def tree_map_only(ty: Type[T], fn: Callable[[T], Any], pytree: PyTree) -> PyTree:
+    """Maps a pytree of a certain type with a given function"""
+    return tree_map(map_only(ty)(fn), pytree)
+
+
+def register_tuple(typ: Any):
+    _register_pytree_node(typ, _namedtuple_flatten, _namedtuple_unflatten)
+
+
+class MultipleInheritanceNamedTupleMeta(typing.NamedTupleMeta):
+    """A meta class to instantiate and register named tuples"""
+
+    def __new__(mcls, typename, bases, ns):
+        cls_obj = super().__new__(mcls, typename + "_nm_base", (NamedTuple,), ns)
+        t = type(typename, bases + (cls_obj,), {})
+        register_tuple(t)  # Registers the tuple in the pytree registry
+        return t
+
+
+class StateTuple:
+    """
+    A base class for state-tuples that allow operations like `cuda`, `to`, `int`, etc.
+
+    Usage:
+    >>> from norse.torch.utils import pytree
+    >>> class SomeState(pytree.NamedTuple, pytree.BaseTuple):
+    >>>     x: torch.Tensor = torch.tensor(0.0)
+    >>>
+    >>> s = SomeState()
+    >>> s.x # torch.tensor([0])
+    """
+
+    def broadcast(self, template: torch.Tensor):
+        """
+        Broadcasts a state tensor according to a given template, returning a tensor of the same shape on the same device.
+
+        Example
+        >>> input_tensor = ...
+        >>> state.broadcast(input_tensor)
+
+        Arguments:
+            template (torch.Tensor): The tensor template whose shape we broadcast to
+        """
+        return tree_map_only(
+            torch.Tensor,
+            functools.partial(broadcast_input, template=template),
+            self,
+        )
+
+    def cuda(self):
+        return self.to("cuda")
+
+    def cpu(self):
+        return self.to("cpu")
+
+    def int(self):
+        return tree_map_only(torch.Tensor, lambda x: x.int(), self)
+
+    def float(self):
+        return tree_map_only(torch.Tensor, lambda x: x.float(), self)
+
+    def to(self, device):
+        return tree_map_only(
+            torch.Tensor, lambda x: x.to(device).requires_grad_(x.requires_grad), self
+        )
+
+
+def broadcast_input(potential_scalar: Any, template: torch.Tensor):
+    if (  # Is single-value tensor
+        isinstance(potential_scalar, torch.Tensor) and potential_scalar.numel() == 1
+    ) or (  # Is scalar
+        isinstance(potential_scalar, Number)
+    ):  # Is similarly-shaped tensor
+        return torch.full_like(template, potential_scalar.item())
+    elif (
+        isinstance(potential_scalar, torch.Tensor)
+        and potential_scalar.shape == template.shape
+    ):
+        return potential_scalar
+    else:
+        raise ValueError(
+            f"Cannot broadcast tensor because it is non-scalar (shape {potential_scalar.shape}) with a different shape than the template ({template.shape})"
+        )

--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -1,7 +1,9 @@
 import functools
 from numbers import Number
 import typing
-from typing import Any, Callable, Type, TypeVar
+# pytype: disable=import-error
+from typing import Any, Callable, Type, TypeVar, NamedTupleMeta
+# pytype: enable=import-error
 
 import torch
 from torch.utils._pytree import (
@@ -50,7 +52,7 @@ def register_tuple(typ: Any):
     _register_pytree_node(typ, _namedtuple_flatten, _namedtuple_unflatten)
 
 
-class MultipleInheritanceNamedTupleMeta(typing.NamedTupleMeta):
+class MultipleInheritanceNamedTupleMeta(NamedTupleMeta):
     """A meta class to instantiate and register named tuples"""
 
     def __new__(mcls, typename, bases, ns):

--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -1,8 +1,10 @@
 import functools
 from numbers import Number
 import typing
+
 # pytype: disable=import-error
 from typing import Any, Callable, Type, TypeVar, NamedTupleMeta
+
 # pytype: enable=import-error
 
 import torch

--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -1,7 +1,7 @@
 import functools
 from numbers import Number
 import typing
-from typing import Any, Callable, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Type, TypeVar
 
 import torch
 from torch.utils._pytree import (

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -39,12 +39,14 @@ def test_state_clone():
 
 
 def test_to_device():
-    if torch.has_cuda:
+    try:
         r = torch.randn(2)
         s = MockState(r)
         sg = s.to("cuda")
         assert sg.x.device.type == "cuda"
         assert sg.y.device.type == "cuda"
+    except RuntimeError:
+        pass  # Ignore non-cuda systems
 
     s = MockState(torch.randn(2))
     s.cpu()

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -1,0 +1,100 @@
+from numbers import Number
+
+import torch
+import onnx
+
+import pytest
+
+import norse.torch.utils.pytree as pytree
+
+
+class MockState(pytree.StateTuple, metaclass=pytree.MultipleInheritanceNamedTupleMeta):
+    x: torch.Tensor
+    y: torch.Tensor = torch.randn(10, 2)
+    z: float = 1.28
+
+
+class MockModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.s = MockState(torch.randn(10, 2))
+
+    def forward(self, x, s: MockState):
+        return x + self.s.x + self.s.y + s[0] + s[1]
+
+
+def test_state_create():
+    x = torch.randn(10, 2)
+    s = MockState(x=x)
+    assert torch.all(torch.eq(s.x, x))
+    assert s.y.shape == (10, 2)
+    assert s.z == 1.28
+
+
+def test_state_clone():
+    x = torch.randn(2)
+    s1 = MockState(x=x)
+    s2 = MockState(x=s1.x + 1)
+    assert torch.allclose(s1.x, s2.x - 1)
+
+
+def test_to_device():
+    if torch.has_cuda:
+        r = torch.randn(2)
+        s = MockState(r)
+        sg = s.to("cuda")
+        assert sg.x.device.type == "cuda"
+        assert sg.y.device.type == "cuda"
+
+    s = MockState(torch.randn(2))
+    s.cpu()
+    assert s.x.device.type == "cpu"
+    assert s.y.device.type == "cpu"
+
+
+def test_to_float():
+    s = MockState(torch.zeros(2, dtype=torch.int32), torch.zeros(2, dtype=torch.int32))
+    assert s.x.dtype == torch.int32
+    assert s.y.dtype == torch.int32
+    s2 = s.float()
+    assert s2.x.dtype == torch.float32
+    assert s2.y.dtype == torch.float32
+
+
+def test_to_int():
+    s = MockState(torch.randn(2))
+    assert s.x.dtype == torch.float32
+    assert s.y.dtype == torch.float32
+    s2 = s.int()
+    assert s2.x.dtype == torch.int32
+    assert s2.y.dtype == torch.int32
+
+
+def test_broadcast():
+    s = MockState(torch.randn(2))
+    assert s.x.shape == (2,)
+
+    with pytest.raises(ValueError):
+        s.broadcast(torch.zeros(10, 2))
+
+    # Single-value tensor
+    s = MockState(torch.randn(1), torch.randn(1))
+    s2 = s.broadcast(torch.zeros(3, 2))
+    assert s2.x.shape == (3, 2)
+    assert s2.y.shape == (3, 2)
+
+    # Scalar
+    s = MockState(0, 1)
+    assert s.x == 0
+    assert s.y == 1
+    s3 = s.broadcast(torch.zeros(2, 1))
+    assert isinstance(s3.x, Number)
+    assert isinstance(s3.y, Number)
+
+
+def test_onnx():
+    m = MockModule()
+    s = MockState(torch.randn(10, 2))
+    torch.onnx.export(m, (torch.randn(10, 2), s), "pytree.onnx")
+    loaded = onnx.load("pytree.onnx")
+    onnx.checker.check_model(loaded)

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -7,6 +7,7 @@ import pytest
 
 import norse.torch.utils.pytree as pytree
 
+# pytype: disable=wrong-arg-count,wrong-keyword-args,unsupported-operands
 
 class MockState(pytree.StateTuple, metaclass=pytree.MultipleInheritanceNamedTupleMeta):
     x: torch.Tensor

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -9,6 +9,7 @@ import norse.torch.utils.pytree as pytree
 
 # pytype: disable=wrong-arg-count,wrong-keyword-args,unsupported-operands
 
+
 class MockState(pytree.StateTuple, metaclass=pytree.MultipleInheritanceNamedTupleMeta):
     x: torch.Tensor
     y: torch.Tensor = torch.randn(10, 2)

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -46,7 +46,7 @@ def test_to_device():
         sg = s.to("cuda")
         assert sg.x.device.type == "cuda"
         assert sg.y.device.type == "cuda"
-    except RuntimeError:
+    except (RuntimeError, AssertionError):
         pass  # Ignore non-cuda systems
 
     s = MockState(torch.randn(2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-torch>=1.9.0
-torchvision>=0.10.0
+torch>=2.0.0
+torchvision>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
This PR serves as place to discuss adding functionality to states. It's meant to partially address #181, improve usability, and slowly start having a crack at #200.

Concretely, I'm suggesting that we adds functions to states that lets us _almost_ treat them as tensors, while retaining support for Python's native Tuples as used in PyTorch's JIT'ing and ONNX.
The code will let us reformulate states as:

```python
from norse.torch.utils.pytree import StateTuple, MultipleInheritanceNamedTupleMeta
class LIFState(StateTuple, metaclass=MultipleInheritanceNamedTupleMeta):
    z: torch.Tensor
    v: torch.Tensor
    i: torch.Tensor
```

Which lets users do stuff like the following:
```python
s = LIFState(z=torch.as_tensor(0.0), v=torch.as_tensor(-65.0), i=torch.as_tensor(0.0))
s.to("cuda") # Move all tensors to cuda
s.int() # Convert all tensors to int
s.float() # Convert all tensors to float
s.broadcast(torch.empty(10, 20)) # Broadcast to shape of the given tensor
```

Note that this also works with default values and numeric members, although they won't be touched since they're outside the scope of PyTorch.

If there is support for this, we can roll it out to the states in the various models.