### PR TITLE
ci: spack nightly build was broken

### DIFF
--- a/.github/workflows/spack_build_nightly.yml
+++ b/.github/workflows/spack_build_nightly.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.9]
+        compiler-version: [gcc@11.3.0]
         spack-python: ['python@3.7', 'python@3.10']
         spack-pytorch: ['py-torch@1.9', 'py-torch@1.11']
         exclude:
@@ -28,4 +29,5 @@ jobs:
         env:
           MATRIX_SPACK_PYTHON: ${{ matrix.spack-python }}
           MATRIX_SPACK_PYTORCH: ${{ matrix.spack-pytorch }}
+          COMPILER_VERSION: ${{ matrix.compiler-version }}
         run: .github/spack/build_spack_package.sh


### PR DESCRIPTION
This introduces the same compiler version as in the spack_build.yml.