### PR TITLE
Constrain pytorch-lightning version in example tasks README

### DIFF
--- a/norse/task/README.md
+++ b/norse/task/README.md
@@ -11,8 +11,8 @@ python -m norse.task.mnist
 ```
 
 Or, using [PyTorch Lightning](https://pytorchlightning.ai/) to scale to multiple GPUs and simplify a lot of the
-boilerplate code around logging, checkpointing, etc. **Note** that this requires you to install PyTorch Lightning
-(`pip install pytorch-lightning`).
+boilerplate code around logging, checkpointing, etc. **Note** that this requires you to install PyTorch Lightning v1
+(`pip install "pytorch-lightning<2.0"`).
 
 ```bash
 python -m norse.task.mnist_pl --gpus=4


### PR DESCRIPTION
Lightning v2.0 was released recently and this is the default version installed with `pip install pytorch-lightning`

Unfortunately v2.0 removes the `pl.Trainer.add_argparse_args(parser)` function, which breaks the example tasks e.g. [cifar10.py](https://github.com/norse/norse/blob/main/norse/task/cifar10.py#L197) (#369)

This small PR updates the pytorch-lightning installation instructions to specify that pytorch-lightning v1 be used
