### PR TITLE
fix: current code depends (at least) on torch >= 2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy",
-  "torch>=2.0.0",
+  "torch>=2.2.0",
   "torchvision>=0.15.0",
   "nir",
   "nirtorch",


### PR DESCRIPTION
When trying `import norse` in the latest RC of the EBRAINS Software Distribution (24.04-RC), I get:

```
ImportError: cannot import name 'register_pytree_node' from 'torch.utils._pytree' (/srv/main-spack-instance-2402/spack/var/spack/environments/experimental/.spack-env/view/lib/python3.8/site-packages/torch/utils/_pytree.py)
```

This seems to be caused by a wrong dependency statement in terms of torch.
The used function has only been introduced in torch 2.2.0.