### PR TITLE
fix for Lift of LICell

### DIFF
--- a/norse/torch/module/leaky_integrator.py
+++ b/norse/torch/module/leaky_integrator.py
@@ -85,7 +85,7 @@ class LICell(SNNCell):
         state = LIState(
             v=self.p.v_leak.detach(),
             i=torch.zeros(
-                *input_tensor.shape,
+                input_tensor.shape,
                 device=input_tensor.device,
                 dtype=input_tensor.dtype,
             ),

--- a/norse/torch/module/test/test_lift.py
+++ b/norse/torch/module/test/test_lift.py
@@ -4,6 +4,7 @@ import platform
 import torch
 
 from norse.torch.module.lif import LIF, LIFCell, LIFFeedForwardState
+from norse.torch.module.leaky_integrator import LICell, LIState
 from norse.torch.module.lift import Lift
 from norse.torch.module.sequential import SequentialState
 
@@ -43,6 +44,14 @@ def test_lift_stateful():
     assert type(out) == tuple
     assert out[0].shape == (5, 2)
     assert type(out[1]) == LIFFeedForwardState
+
+def test_lift_LICell():
+    c = Lift(LICell())
+    data = torch.randn(5, 2)
+    out = c(data)
+    assert type(out) == tuple
+    assert out[0].shape == (5, 2)
+    assert type(out[1]) == LIState
 
 
 def test_lift_sequential_stateful():

--- a/norse/torch/module/test/test_lift.py
+++ b/norse/torch/module/test/test_lift.py
@@ -45,6 +45,7 @@ def test_lift_stateful():
     assert out[0].shape == (5, 2)
     assert type(out[1]) == LIFFeedForwardState
 
+
 def test_lift_LICell():
     c = Lift(LICell())
     data = torch.randn(5, 2)

--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -14,6 +14,7 @@ from torch.utils._pytree import (
     _namedtuple_unflatten,
     tree_map,
 )
+
 try:
     from torch.utils._pytree import register_pytree_node
 except ImportError:


### PR DESCRIPTION
This is a fix for the error that occurs when performing Lift() in LICell() modules:
```
TypeError: zeros() received an invalid combination of arguments - got (dtype=torch.dtype, device=torch.device, ), but expected one of:
 * (tuple of ints size, *, tuple of names names, torch.dtype dtype, torch.layout layout, torch.device device, bool pin_memory, bool requires_grad)
 * (tuple of ints size, *, Tensor out, torch.dtype dtype, torch.layout layout, torch.device device, bool pin_memory, bool requires_grad)
```
