### PR TITLE
RF log update fix

### DIFF
--- a/norse/torch/module/receptive_field.py
+++ b/norse/torch/module/receptive_field.py
@@ -51,7 +51,7 @@ class SpatialReceptiveField2d(torch.nn.Module):
         aggregate: bool = True,
         domain: float = 8,
         optimize_fields: bool = True,
-        optimize_log: bool = False,
+        optimize_log: bool = True,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -234,7 +234,7 @@ class SampledSpatialReceptiveField2d(torch.nn.Module):
         optimize_ratios: bool = True,
         optimize_x: bool = True,
         optimize_y: bool = True,
-        optimize_log: bool = False,
+        optimize_log: bool = True,
         **kwargs,
     ):
         super().__init__()
@@ -349,7 +349,7 @@ class ParameterizedSpatialReceptiveField2d(torch.nn.Module):
         optimize_ratios: bool = True,
         optimize_x: bool = True,
         optimize_y: bool = True,
-        optimize_log: bool = False,
+        optimize_log: bool = True,
         **kwargs,
     ):
         super().__init__()

--- a/norse/torch/module/receptive_field.py
+++ b/norse/torch/module/receptive_field.py
@@ -7,7 +7,6 @@ For use in spiking / binary signals, see the paper on `Translation and Scale Inv
 from typing import Callable, NamedTuple, Optional, Tuple
 
 import torch
-import traceback
 
 from norse.torch.module.snn import SNNCell
 from norse.torch.module.leaky_integrator_box import LIBoxCell, LIBoxParameters

--- a/norse/torch/module/test/test_receptive_field.py
+++ b/norse/torch/module/test/test_receptive_field.py
@@ -28,7 +28,7 @@ def test_spatial_receptive_field_update_flag():
 
 def test_spatial_receptive_field_update_kernels():
     parameters = torch.tensor([[1, 0, 1, 0, 0, 0, 0.0]])
-    m = SpatialReceptiveField2d(1, 9, rf_parameters=parameters)
+    m = SpatialReceptiveField2d(1, 9, rf_parameters=parameters, optimize_log=False)
     old_kernels = m.weights.detach().clone()
     optim = torch.optim.SGD(list(m.parameters()), lr=1)
     y = m(torch.eye(9).view(1, 1, 9, 9))
@@ -52,7 +52,20 @@ def test_spatially_parameterized_receptive_field_update():
     ratios_copy = ratios.clone()
     x_copy = x.clone()
     m = SampledSpatialReceptiveField2d(
-        1, 9, scales, angles, ratios, 1, x, y, False, False, True, True, False
+        1,
+        9,
+        scales,
+        angles,
+        ratios,
+        1,
+        x,
+        y,
+        False,
+        False,
+        True,
+        True,
+        False,
+        optimize_log=False,
     )
     old_kernels = m.submodule.weights.detach().clone()
     optim = torch.optim.SGD(list(m.parameters()), lr=1)
@@ -79,7 +92,20 @@ def test_column_parameterized_receptive_field_update():
     x = torch.tensor([0.0, 1.0])
     y = torch.tensor([0.0, 1.0])
     m = ParameterizedSpatialReceptiveField2d(
-        1, 9, scales, angles, ratios, 1, x, y, False, False, True, True, False
+        1,
+        9,
+        scales,
+        angles,
+        ratios,
+        1,
+        x,
+        y,
+        False,
+        False,
+        True,
+        True,
+        False,
+        optimize_log=False,
     )
     ratios_copy = m.ratios.clone()
     x_copy = m.x.clone()
@@ -120,6 +146,7 @@ def test_column_parameterized_receptive_field_update_default_xy():
         optimize_ratios=True,
         optimize_x=True,
         optimize_y=False,
+        optimize_log=False,
     )
     ratios_copy = m.ratios.clone()
     x_copy = m.x.clone()


### PR DESCRIPTION
Fix error due to default optimize_log set to True
Fix device mismatch error on backward pass by setting the has_updated parameter in the RF __init__() functions to True 