### PR TITLE
Added NIR export support for multiple modules

### DIFF
--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -31,11 +31,13 @@ def _norse_to_nir_mapping_dict(
 ) -> typing.Dict[torch.nn.Module, typing.Callable[[torch.nn.Module], nir.NIRNode]]:
     norse_map = {}
 
+    # Projections
+
     def _map_conv2d(module: torch.nn.Conv2d):
         return nir.Conv2d(
             input_shape=None,
             weight=module.weight.detach().numpy(),
-            bias=module.bias.detach().numpy(),
+            bias=module.bias.detach().numpy() if module.bias is not None else np.zeros(module.weight.shape[0]),
             stride=module.stride,
             padding=module.padding,
             dilation=module.dilation,
@@ -44,7 +46,52 @@ def _norse_to_nir_mapping_dict(
 
     norse_map[torch.nn.Conv2d] = _map_conv2d
 
-    def _map_cuba_lif(module: nir.CubaLIF):
+    def _map_conv1d(module: torch.nn.Conv1d):
+        return nir.Conv1d(
+            input_shape=None,
+            weight=module.weight.detach().numpy(),
+            bias=module.bias.detach().numpy() if module.bias is not None else np.zeros(module.weight.shape[0]),
+            stride=module.stride,
+            padding=module.padding,
+            dilation=module.dilation,
+            groups=module.groups,
+        )
+
+    norse_map[torch.nn.Conv1d] = _map_conv1d
+
+    def _map_linear(module: torch.nn.Linear):
+        if module.bias is None:
+            return nir.Linear(module.weight.detach().numpy())
+        else:
+            return nir.Affine(module.weight.detach().numpy(), module.bias.detach().numpy())
+
+    norse_map[torch.nn.Linear] = _map_linear
+
+    def _map_flatten(module: torch.nn.Flatten):
+        # The Flatten node usually skips one dimension and starts at dimension 1.
+        # This is because the batch dimension is not being flattened. However, NIR
+        # doesn't include the batch dimension in its input/output shapes, which is
+        # why we subtract 1 from the start dimension and end dimension.
+        return nir.Flatten(
+            input_type=None,
+            start_dim=module.start_dim - 1 if module.start_dim > 0 else module.end_dim,
+            end_dim=module.end_dim - 1 if module.end_dim > 0 else module.end_dim
+        )
+
+    norse_map[torch.nn.Flatten] = _map_flatten
+
+    def _map_avgpool2d(module: torch.nn.AvgPool2d):
+        return nir.AvgPool2d(
+            kernel_size=module.kernel_size,
+            stride=module.stride,
+            padding=module.padding
+        )
+
+    norse_map[torch.nn.AvgPool2d] = _map_avgpool2d
+
+    # Neurons
+
+    def _map_cuba_lif(module: norse.torch.LIFCell):
         shape = module.p.tau_mem_inv.shape
         return nir.CubaLIF(
             tau_mem=time_scaling_factor
@@ -63,6 +110,24 @@ def _norse_to_nir_mapping_dict(
         )
 
     norse_map[norse.torch.LIFCell] = _map_cuba_lif
+
+    def _map_leaky_integrator(module: norse.torch.LICell):
+        shape = module.p.tau_mem_inv.shape
+        return nir.CubaLI(
+            tau_mem=time_scaling_factor
+            / _align_shapes(
+                module.p.tau_mem_inv.detach(), shape, "tau_syn"
+            ).numpy(),  # Invert time constant
+            tau_syn=time_scaling_factor
+            / _align_shapes(
+                module.p.tau_syn_inv.detach(), shape, "tau_syn"
+            ).numpy(),  # Invert time constant
+            v_leak=_align_shapes(module.p.v_leak.detach(), shape, "v_leak").numpy(),
+            r=np.ones_like(module.p.v_leak.detach().numpy()),
+            w_in=np.ones_like(module.p.v_leak.detach().numpy()),
+        )
+
+    norse_map[norse.torch.LICell] = _map_leaky_integrator
 
     def _map_lif_box(module: norse.torch.LIFBoxCell):
         shape = module.p.tau_mem_inv.shape
@@ -102,16 +167,6 @@ def _norse_to_nir_mapping_dict(
         )
 
     norse_map[norse.torch.IAFCell] = _map_iaf
-
-    def _map_linear(module: torch.nn.Linear):
-        if module.bias is None:
-            return nir.Linear(module.weight.detach().numpy())
-        else:
-            return nir.Affine(
-                module.weight.detach().numpy(), module.bias.detach().numpy()
-            )
-
-    norse_map[torch.nn.Linear] = _map_linear
 
     return norse_map
 

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -212,6 +212,7 @@ def to_nir(
     stateful_modules = {
         norse.torch.LIFCell,
         norse.torch.LIFBoxCell,
+        norse.torch.LICell,
         norse.torch.LIBoxCell,
         norse.torch.IAFCell,
     }

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -37,7 +37,11 @@ def _norse_to_nir_mapping_dict(
         return nir.Conv2d(
             input_shape=None,
             weight=module.weight.detach().numpy(),
-            bias=module.bias.detach().numpy() if module.bias is not None else np.zeros(module.weight.shape[0]),
+            bias=(
+                module.bias.detach().numpy()
+                if module.bias is not None
+                else np.zeros(module.weight.shape[0])
+            ),
             stride=module.stride,
             padding=module.padding,
             dilation=module.dilation,
@@ -50,7 +54,11 @@ def _norse_to_nir_mapping_dict(
         return nir.Conv1d(
             input_shape=None,
             weight=module.weight.detach().numpy(),
-            bias=module.bias.detach().numpy() if module.bias is not None else np.zeros(module.weight.shape[0]),
+            bias=(
+                module.bias.detach().numpy()
+                if module.bias is not None
+                else np.zeros(module.weight.shape[0])
+            ),
             stride=module.stride,
             padding=module.padding,
             dilation=module.dilation,
@@ -63,7 +71,9 @@ def _norse_to_nir_mapping_dict(
         if module.bias is None:
             return nir.Linear(module.weight.detach().numpy())
         else:
-            return nir.Affine(module.weight.detach().numpy(), module.bias.detach().numpy())
+            return nir.Affine(
+                module.weight.detach().numpy(), module.bias.detach().numpy()
+            )
 
     norse_map[torch.nn.Linear] = _map_linear
 
@@ -75,16 +85,14 @@ def _norse_to_nir_mapping_dict(
         return nir.Flatten(
             input_type=None,
             start_dim=module.start_dim - 1 if module.start_dim > 0 else module.end_dim,
-            end_dim=module.end_dim - 1 if module.end_dim > 0 else module.end_dim
+            end_dim=module.end_dim - 1 if module.end_dim > 0 else module.end_dim,
         )
 
     norse_map[torch.nn.Flatten] = _map_flatten
 
     def _map_avgpool2d(module: torch.nn.AvgPool2d):
         return nir.AvgPool2d(
-            kernel_size=module.kernel_size,
-            stride=module.stride,
-            padding=module.padding
+            kernel_size=module.kernel_size, stride=module.stride, padding=module.padding
         )
 
     norse_map[torch.nn.AvgPool2d] = _map_avgpool2d

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -84,7 +84,9 @@ def _norse_to_nir_mapping_dict(
         # why we subtract 1 from the start dimension and end dimension.
         return nir.Flatten(
             input_type=None,
-            start_dim=module.start_dim - 1 if module.start_dim > 0 else module.start_dim,
+            start_dim=(
+                module.start_dim - 1 if module.start_dim > 0 else module.start_dim
+            ),
             end_dim=module.end_dim - 1 if module.end_dim > 0 else module.end_dim,
         )
 

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -84,7 +84,7 @@ def _norse_to_nir_mapping_dict(
         # why we subtract 1 from the start dimension and end dimension.
         return nir.Flatten(
             input_type=None,
-            start_dim=module.start_dim - 1 if module.start_dim > 0 else module.end_dim,
+            start_dim=module.start_dim - 1 if module.start_dim > 0 else module.start_dim,
             end_dim=module.end_dim - 1 if module.end_dim > 0 else module.end_dim,
         )
 
@@ -124,7 +124,7 @@ def _norse_to_nir_mapping_dict(
         return nir.CubaLI(
             tau_mem=time_scaling_factor
             / _align_shapes(
-                module.p.tau_mem_inv.detach(), shape, "tau_syn"
+                module.p.tau_mem_inv.detach(), shape, "tau_mem"
             ).numpy(),  # Invert time constant
             tau_syn=time_scaling_factor
             / _align_shapes(

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -18,6 +18,40 @@ def test_conv2d():
     assert len(graph.edges) == 2
 
 
+def test_conv1d():
+    m = norse.SequentialState(torch.nn.Conv1d(1, 2, 3))
+    # type_check=False because Conv2d is created without input_shape
+    graph = norse.to_nir(m, type_check=False)
+    assert len(graph.nodes) == 3
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.Conv1d)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 2
+
+
+def test_flatten():
+    m = norse.SequentialState(torch.nn.Flatten())
+    # type_check=False because Conv2d is created without input_shape
+    graph = norse.to_nir(m, type_check=False)
+    assert len(graph.nodes) == 3
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.Flatten)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 2
+
+
+def test_avgpool2d():
+    m = norse.SequentialState(torch.nn.AvgPool2d(kernel_size=2))
+    # type_check=False because Conv2d is created without input_shape
+    graph = norse.to_nir(m, type_check=False)
+    assert len(graph.nodes) == 3
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.AvgPool2d)
+    assert graph.nodes["_0"].kernel_size == 2
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 2
+
+
 def test_sequential():
     m = norse.SequentialState(
         norse.LIFBoxCell(),
@@ -77,6 +111,19 @@ def test_linear():
     assert isinstance(node, nir.Affine)
     assert node.weight.shape == (out_features, in_features)
     assert node.bias.shape == m2.bias.shape
+
+
+def test_li_sequential():
+    network = norse.SequentialState(norse.LICell(), torch.nn.Linear(1, 1))
+    # type_check=False because LIFCell has no inherent shape information
+    # (neurons are element-wise and work with any input size)
+    graph = norse.to_nir(network, type_check=False)
+    assert len(graph.nodes) == 4  # 2 + 2 for input and output
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.CubaLI)
+    assert isinstance(graph.nodes["_1"], nir.Affine)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 3
 
 
 def test_li_varying_time_scaling_factor():

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -20,7 +20,7 @@ def test_conv2d():
 
 def test_conv1d():
     m = norse.SequentialState(torch.nn.Conv1d(1, 2, 3))
-    # type_check=False because Conv2d is created without input_shape
+    # type_check=False because Conv1d is created without input_shape
     graph = norse.to_nir(m, type_check=False)
     assert len(graph.nodes) == 3
     assert isinstance(graph.nodes["input_tensor"], nir.Input)
@@ -31,7 +31,7 @@ def test_conv1d():
 
 def test_flatten():
     m = norse.SequentialState(torch.nn.Flatten())
-    # type_check=False because Conv2d is created without input_shape
+    # type_check=False because Flatten is created without input_shape
     graph = norse.to_nir(m, type_check=False)
     assert len(graph.nodes) == 3
     assert isinstance(graph.nodes["input_tensor"], nir.Input)
@@ -42,7 +42,7 @@ def test_flatten():
 
 def test_avgpool2d():
     m = norse.SequentialState(torch.nn.AvgPool2d(kernel_size=2))
-    # type_check=False because Conv2d is created without input_shape
+    # type_check=False because AvgPool2d is created without input_shape
     graph = norse.to_nir(m, type_check=False)
     assert len(graph.nodes) == 3
     assert isinstance(graph.nodes["input_tensor"], nir.Input)


### PR DESCRIPTION
Adds NIR export support for additional `torch.nn` modules and one `norse.torch` module.

Added mappings include:
* `torch.nn.Conv1d` -> `nir.Conv1d`
* `torch.nn.Flatten` -> `nir.Flatten`
* `torch.nn.AvgPool2d` -> `nir.AvgPool2d`
* `norse.torch.LICell` -> `nir.CubaLI`

**NOTE:**
The `torch.nn.Flatten` module usually skips the first dimension and starts at dimension 1. The first dimension is by convention reserved for the batch dimension during training, and should not be flattened. NIR however does not take batch dimensions into account (and rightfully so). Therefore, when exporting `torch.nn.Flatten` modules to `nir.Flatten` nodes, we should subtract 1 from the start dimension and end dimension.

As an additional bugfix, the export of `torch.nn.Conv2d` layers has been fixed for cases in which the bias is `None` (which previously resulted in an error). Now, the bias of the NIR node is set to all zeros.