### PR TITLE
Add more flexibility for exporting and bypassing of custom modules

### DIFF
--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -122,7 +122,6 @@ def to_nir(
     model_name: str = "norse",
     time_scaling_factor: float = 1,
     custom_stateful_modules: typing.Set[typing.Type[torch.nn.Module]] = set(),
-    custom_bypass_modules: typing.Set[typing.Type[torch.nn.Module]] = set(),
     custom_mapping: typing.Dict[torch.nn.Module, typing.Callable[[torch.nn.Module], nir.NIRNode]] = {},
     type_check: bool = True,
 ) -> nir.NIRNode:
@@ -140,12 +139,11 @@ def to_nir(
         custom_stateful_modules (Set[Type[torch.nn.Module]]): Set of additional custom stateful modules.
             Custom neuron implementation types and other stateful modules can be added to this set to ensure
             correct tracing.
-        custom_bypass_modules (Set[Type[torch.nn.Module]]): Set of modules to bypass when tracing. Modules
-            that do not alter the dataflow (i.e., Dropout, Identity) can be added to this set to ensure
-            correct tracing.
         custom_mapping (Dict[torch.nn.Module, (torch.nn.Module) -> nir.NIRNode]): Dictionary of additional
             custom module mappings. Through entries in this dictionary, custom modules can be mapped to
-            nir.NIRNode primitives in the export process.
+            nir.NIRNode primitives in the export process. Module mappings already present in the default
+            map are overridden. Modules that do not alter the dataflow (i.e., Dropout, Identity) can be
+            mapped to None in order to be bypassed.
         type_check (bool): Whether to run type checking on generated NIRGraphs
     """
     if sample_data is not None:
@@ -181,6 +179,5 @@ def to_nir(
         module_map=combined_dict,
         type_check=type_check,
         stateful_modules=combined_stateful_modules,
-        bypass_modules=custom_bypass_modules,
         concrete_args={"state": None},
     )

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -121,6 +121,8 @@ def to_nir(
     sample_data: typing.Optional[torch.Tensor] = None,
     model_name: str = "norse",
     time_scaling_factor: float = 1,
+    custom_stateful_modules: typing.Set[typing.Type[torch.nn.Module]] = set(),
+    custom_mapping: typing.Dict[torch.nn.Module, typing.Callable[[torch.nn.Module], nir.NIRNode]] = {},
     type_check: bool = True,
 ) -> nir.NIRNode:
     """Converts a Norse module to a NIR graph.
@@ -134,6 +136,12 @@ def to_nir(
             defaults to 1 which retains the dynamics of the neuron equation. However, if your network has
             been trained with a different dt, this scaling factor can re-scale the network dynamics as
             needed.
+        custom_stateful_modules (Set[Type[torch.nn.Module]]): Set of additional custom stateful modules.
+            Custom neuron implementation types and other stateful modules can be added to this set to ensure
+            correct tracing.
+        custom_mapping (Dict[torch.nn.Module, (torch.nn.Module) -> nir.NIRNode]): Dictionary of additional
+            custom module mappings. Through entries in this dictionary, custom modules can be mapped to
+            nir.NIRNode primitives in the export process.
         type_check (bool): Whether to run type checking on generated NIRGraphs
     """
     if sample_data is not None:
@@ -151,20 +159,23 @@ def to_nir(
         )
 
     mapping_dict = _norse_to_nir_mapping_dict(time_scaling_factor=time_scaling_factor)
+    combined_dict = mapping_dict | custom_mapping
 
     # Define stateful modules that return (output, state) tuples
     # These modules need special handling during tracing
     stateful_modules = {
         norse.torch.LIFCell,
         norse.torch.LIFBoxCell,
+        norse.torch.LICell,
         norse.torch.LIBoxCell,
         norse.torch.IAFCell,
     }
+    combined_stateful_modules = stateful_modules | custom_stateful_modules
 
     return nirtorch.torch_to_nir(
         module=module,
-        module_map=mapping_dict,
+        module_map=combined_dict,
         type_check=type_check,
-        stateful_modules=stateful_modules,
+        stateful_modules=combined_stateful_modules,
         concrete_args={"state": None},
     )

--- a/norse/torch/utils/export_nir.py
+++ b/norse/torch/utils/export_nir.py
@@ -122,6 +122,7 @@ def to_nir(
     model_name: str = "norse",
     time_scaling_factor: float = 1,
     custom_stateful_modules: typing.Set[typing.Type[torch.nn.Module]] = set(),
+    custom_bypass_modules: typing.Set[typing.Type[torch.nn.Module]] = set(),
     custom_mapping: typing.Dict[torch.nn.Module, typing.Callable[[torch.nn.Module], nir.NIRNode]] = {},
     type_check: bool = True,
 ) -> nir.NIRNode:
@@ -138,6 +139,9 @@ def to_nir(
             needed.
         custom_stateful_modules (Set[Type[torch.nn.Module]]): Set of additional custom stateful modules.
             Custom neuron implementation types and other stateful modules can be added to this set to ensure
+            correct tracing.
+        custom_bypass_modules (Set[Type[torch.nn.Module]]): Set of modules to bypass when tracing. Modules
+            that do not alter the dataflow (i.e., Dropout, Identity) can be added to this set to ensure
             correct tracing.
         custom_mapping (Dict[torch.nn.Module, (torch.nn.Module) -> nir.NIRNode]): Dictionary of additional
             custom module mappings. Through entries in this dictionary, custom modules can be mapped to
@@ -177,5 +181,6 @@ def to_nir(
         module_map=combined_dict,
         type_check=type_check,
         stateful_modules=combined_stateful_modules,
+        bypass_modules=custom_bypass_modules,
         concrete_args={"state": None},
     )

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -270,10 +270,12 @@ def test_bypass_module():
         torch.nn.Linear(2, 1),
     )
 
-    bypass_modules = {torch.nn.Dropout}
+    def map_none(_):
+        return None
 
-    # type_check=False because neuron models lack shape information
-    graph = norse.to_nir(m, type_check=False, custom_bypass_modules=bypass_modules)
+    bypass_map = {torch.nn.Dropout: map_none}
+
+    graph = norse.to_nir(m, type_check=False, custom_mapping=bypass_map)
     assert len(graph.nodes) == 6  # 4 + 2 for input and output
     assert isinstance(graph.nodes["input_tensor"], nir.Input)
     assert isinstance(graph.nodes["_0"], nir.LIF)

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -259,3 +259,27 @@ def test_custom_module_stateful():
     assert isinstance(graph.nodes["_3"], nir.Affine)
     assert isinstance(graph.nodes["output"], nir.Output)
     assert len(graph.edges) == 5
+
+
+def test_bypass_module():
+    m = norse.SequentialState(
+        norse.LIFBoxCell(),
+        torch.nn.Linear(10, 2),
+        torch.nn.Dropout(),
+        norse.LIBoxCell(),
+        torch.nn.Linear(2, 1),
+    )
+
+    bypass_modules = {torch.nn.Dropout}
+
+    # type_check=False because neuron models lack shape information
+    graph = norse.to_nir(m, type_check=False, custom_bypass_modules=bypass_modules)
+    assert len(graph.nodes) == 6  # 4 + 2 for input and output
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.LIF)
+    assert isinstance(graph.nodes["_1"], nir.Affine)
+    assert "_2" not in graph.nodes  # 'Dropout' not present because it has been bypassed
+    assert isinstance(graph.nodes["_3"], nir.LI)
+    assert isinstance(graph.nodes["_4"], nir.Affine)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 5

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -182,3 +182,80 @@ def test_lif_box_v_reset_default():
     assert isinstance(node.v_leak, np.ndarray)
     assert np.allclose(node.v_reset, np.zeros_like(p.v_leak.numpy()))
     assert isinstance(node.v_reset, np.ndarray)
+
+
+def test_custom_module():
+    # Create custom module and define how it is mapped to NIR primitives
+    class CustomModule(torch.nn.Module):
+        def forward(self, x):
+            return x
+
+    def _map_custom_neuron(_: CustomModule):
+        return nir.LIF(
+            tau=np.array(1.0),
+            r=np.array(1.0),
+            v_leak=np.array(0.0),
+            v_threshold=np.array(1.0),
+            v_reset=np.array(0.0)
+        )
+
+    custom_mapping = { CustomModule: _map_custom_neuron }
+
+    m = norse.SequentialState(
+        CustomModule(),
+        torch.nn.Linear(10, 2),
+        norse.LIBoxCell(),
+        torch.nn.Linear(2, 1),
+    )
+
+    # type_check=False because neuron models lack shape information
+    graph = norse.to_nir(m, type_check=False, custom_mapping=custom_mapping)
+    assert len(graph.nodes) == 6  # 4 + 2 for input and output
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.LIF)
+    assert isinstance(graph.nodes["_1"], nir.Affine)
+    assert isinstance(graph.nodes["_2"], nir.LI)
+    assert isinstance(graph.nodes["_3"], nir.Affine)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 5
+
+
+def test_custom_module_stateful():
+    # Create custom stateful module and define how it is mapped to NIR primitives
+    class CustomStatefulModule(torch.nn.Module):
+        def forward(self, x, state):
+            return x, state
+
+    def _map_custom_neuron(_: CustomStatefulModule):
+        return nir.LIF(
+            tau=np.array(1.0),
+            r=np.array(1.0),
+            v_leak=np.array(0.0),
+            v_threshold=np.array(1.0),
+            v_reset=np.array(0.0)
+        )
+
+    custom_stateful_modules = { CustomStatefulModule }
+    custom_mapping = { CustomStatefulModule: _map_custom_neuron }
+
+    m = norse.SequentialState(
+        CustomStatefulModule(),
+        torch.nn.Linear(10, 2),
+        norse.LIBoxCell(),
+        torch.nn.Linear(2, 1),
+    )
+
+    # type_check=False because neuron models lack shape information
+    graph = norse.to_nir(
+        m, type_check=False,
+        custom_stateful_modules=custom_stateful_modules,
+        custom_mapping=custom_mapping
+    )
+    assert len(graph.nodes) == 6  # 4 + 2 for input and output
+    assert isinstance(graph.nodes["input_tensor"], nir.Input)
+    assert isinstance(graph.nodes["_0"], nir.LIF)
+    assert isinstance(graph.nodes["_1"], nir.Affine)
+    assert isinstance(graph.nodes["_2"], nir.LI)
+    assert isinstance(graph.nodes["_3"], nir.Affine)
+    assert isinstance(graph.nodes["output"], nir.Output)
+    assert len(graph.edges) == 5

--- a/norse/torch/utils/test/test_nir_export.py
+++ b/norse/torch/utils/test/test_nir_export.py
@@ -280,7 +280,7 @@ def test_bypass_module():
     assert isinstance(graph.nodes["input_tensor"], nir.Input)
     assert isinstance(graph.nodes["_0"], nir.LIF)
     assert isinstance(graph.nodes["_1"], nir.Affine)
-    assert "_2" not in graph.nodes  # 'Dropout' not present because it has been bypassed
+    assert "_2" not in graph.nodes  # 'Dropout' is not present because it has been bypassed
     assert isinstance(graph.nodes["_3"], nir.LI)
     assert isinstance(graph.nodes["_4"], nir.Affine)
     assert isinstance(graph.nodes["output"], nir.Output)


### PR DESCRIPTION
Currently, only mappings defined inside Norse are valid for exporting `torch.nn` models to NIR. However, custom variations of Norse neuron implementations can exist that should still map to a specific NIR primitive. This pull request adds two contributions:

### Support for mapping custom modules to NIR primitives
The `to_nir` function has been extended to accept a `custom_mapping` parameter. This parameter is a dictionary mapping `torch.nn.Module` subtypes to NIR primitives and enables users of Norse to specify additional mappings from custom neuron implementations. It gets combined with the `mapping_dict` defined by Norse. Additionally, a `custom_stateful_modules` analogous to the `stateful_modules` set by Norse has been added to ensure correct tracing of custom stateful modules.

### Support for bypassing no-op and transparent modules
This change depends on neuromorphs/NIRTorch#50, and targets the selective bypassing of user-specified modules. Modules like `torch.nn.Dropout` or `torch.nn.Identity` do not contribute to the computation at runtime, and can therefore be viewed as transparent. This change exposes the functionality added in the NIRTorch pull request in Norse, enabling uses to bypass selected modules during tracing.