### PR TITLE
fix(pytree): preserve __module__/__qualname__ on metaclass-built state tuples

### DIFF
--- a/norse/torch/utils/pytree.py
+++ b/norse/torch/utils/pytree.py
@@ -63,7 +63,19 @@ class MultipleInheritanceNamedTupleMeta(NamedTupleMeta):
 
     def __new__(mcls, typename, bases, ns):
         cls_obj = super().__new__(mcls, typename + "_nm_base", (NamedTuple,), ns)
-        t = type(typename, bases + (cls_obj,), {})
+        # Carry over ``__module__`` and ``__qualname__`` from the original class
+        # namespace so the generated type is discoverable where it is actually
+        # defined. Without this, ``type()`` records this module
+        # (``norse.torch.utils.pytree``) as the home of every state tuple, which
+        # breaks pickling/``torch.save`` (see issue #414).
+        t = type(
+            typename,
+            bases + (cls_obj,),
+            {
+                "__module__": ns.get("__module__", mcls.__module__),
+                "__qualname__": ns.get("__qualname__", typename),
+            },
+        )
         register_tuple(t)  # Registers the tuple in the pytree registry
         return t
 

--- a/norse/torch/utils/test/test_pytree.py
+++ b/norse/torch/utils/test/test_pytree.py
@@ -37,6 +37,28 @@ def test_state_create():
     assert s.z == 1.28
 
 
+def test_state_pickle_module_path():
+    # Regression test for issue #414: the generated state tuple must report the
+    # module in which it is defined so that pickle can find it again.
+    assert MockState.__module__ == __name__
+    assert MockState.__qualname__ == "MockState"
+
+
+def test_serialize():
+    # Regression test for issue #414: state tuples produced by the metaclass
+    # must survive a torch.save/torch.load round-trip (previously raised
+    # PicklingError: attribute lookup ... failed).
+    import io
+
+    s = MockState(torch.rand(10))
+    buffer = io.BytesIO()
+    torch.save(s, buffer)
+    buffer.seek(0)
+    new_s = torch.load(buffer, weights_only=False)
+    assert isinstance(new_s, MockState)
+    assert torch.allclose(s.x, new_s.x)
+
+
 def test_state_is_tuple():
     s = MockState(torch.randn(1))
     assert isinstance(s, Tuple)


### PR DESCRIPTION
## Intent
Fixes #414 

Fix broken pickling/torch.save serialization of LIFParameters and other neuron state tuples produced by the pytree metaclass

## What Changed

- `MultipleInheritanceNamedTupleMeta.__new__` now copies `__module__` and `__qualname__` from the original class namespace onto the type it synthesizes, instead of leaving them defaulted to `norse.torch.utils.pytree`. This makes state tuples like `LIFParameters` report the module where they are actually defined, restoring pickling and `torch.save`/`torch.load` round-trips (issue #414).
- Added regression tests in `test_pytree.py` (`test_state_pickle_module_path` and `test_serialize`) covering the module path and serialization behavior.

## Risk Assessment

✅ Low: Minimal, well-scoped fix that copies __module__/__qualname__ from the original class namespace onto the metaclass-generated type, with a regression test covering both attribute correctness and an actual torch.save/load round-trip; no other code paths are touched.

## Testing

Ran the pytree test suite (all pass except one CUDA-only skip) and independently reproduced the end-user scenario from issue #414: torch.save/load of a real LIFParameters instance now succeeds and reports the correct __module__, while re-checking out the pre-fix pytree.py reproduces the original PicklingError verbatim, confirming the fix resolves the reported bug.

<details>
<summary>Evidence: LIFParameters torch.save/load round-trip log</summary>

<code>module: norse.torch.functional.lif&#10;qualname: LIFParameters&#10;round-trip type: &lt;class &#39;norse.torch.functional.lif.LIFParameters&#39;&gt;&#10;round-trip equal tau_syn_inv: True&#10;SUCCESS: LIFParameters pickled and restored via torch.save/torch.load</code>

```text
module: norse.torch.functional.lif
qualname: LIFParameters
round-trip type: <class 'norse.torch.functional.lif.LIFParameters'>
round-trip equal tau_syn_inv: True
SUCCESS: LIFParameters pickled and restored via torch.save/torch.load
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python -m pytest norse/torch/utils/test/test_pytree.py -v` (10 passed, 1 skipped for no-CUDA) — includes new regression tests test_state_pickle_module_path and test_serialize</code>
- `Manual end-to-end repro: torch.save/torch.load round-trip of norse.torch.functional.lif.LIFParameters on the target commit — succeeds, __module__ correctly reports norse.torch.functional.lif`
- `Manual bisect: same script against base commit e4a273b's pytree.py — reproduces the exact reported PicklingError: Can't pickle <class 'norse.torch.utils.pytree.LIFParameters'>`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
